### PR TITLE
fix(build-service): make `foundry serve` work end-to-end on the OAuth subscription

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -47,14 +47,30 @@ services:
     ports:
       - "8787:8787"
       - "8788:8788"
-    # The docker socket is required by the local_docker backend, which
-    # launches builder and preview containers on the host daemon.
+    # Run as the foundry-builder image's `builder` uid (10001) so per-job work
+    # dirs the service stages are owner-writable by the builder container; the
+    # gid is the host docker group, needed to use the mounted docker socket.
+    # Set FOUNDRY_SERVICE_USER (e.g. 10001:<docker-gid>) in .env.
+    user: "${FOUNDRY_SERVICE_USER:-}"
     volumes:
+      # The docker socket is required by the local_docker backend, which
+      # launches builder and preview containers on the host daemon.
       - /var/run/docker.sock:/var/run/docker.sock
+      # local_docker builds: builder containers run on the HOST daemon, so the
+      # per-job work dir must resolve to the same path the service wrote it to.
+      # Bind-mount the storage dir at an IDENTICAL absolute path on both sides;
+      # FOUNDRY_SERVICE_STORAGE in .env must equal this path.
+      - "${FOUNDRY_SERVICE_STORAGE:-/var/lib/foundry-service-storage}:${FOUNDRY_SERVICE_STORAGE:-/var/lib/foundry-service-storage}"
     # So builder containers' default FOUNDRY_SERVICE_BUILDER_PROXY_URL of
     # http://host.docker.internal:8788 resolves on Linux Docker.
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    networks:
+      # `default` reaches Postgres; `foundry-preview` lets the service reach
+      # preview containers by name to health-check them (they publish no host
+      # port — the network is internal).
+      - default
+      - foundry-preview
     restart: unless-stopped
 
   caddy:
@@ -75,3 +91,12 @@ volumes:
   foundry-pgdata:
   caddy-data:
   caddy-config:
+
+networks:
+  # The isolated network preview containers run on. Declared here so
+  # foundry-service can join it; `name:` pins it un-prefixed so the runtime
+  # `docker run --network foundry-preview` in localdocker.rs targets the same
+  # network. `internal: true` keeps preview containers egress-free.
+  foundry-preview:
+    name: foundry-preview
+    internal: true

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -75,16 +75,22 @@ services:
 
   caddy:
     image: caddy:2-alpine
-    ports:
-      - "80:80"
-      - "443:443"
-    # The service reconfigures Caddy at runtime through its admin API on port
-    # 2019 to add and remove preview routes; the static Caddyfile only
-    # declares the admin endpoint and the API route.
+    container_name: foundry-caddy
+    # No host ports. This Caddy is the previews' internal router, not a public
+    # edge: a front Caddy (the host's real :80/:443 edge) reaches it by
+    # container name over `compose_default` and forwards `*.<preview-domain>`
+    # traffic to it. The build service manages it entirely through its admin
+    # API (port 2019) -- POSTing/DELETEing per-preview routes; the static
+    # Caddyfile only bootstraps the server + admin endpoint.
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data
       - caddy-config:/config
+    networks:
+      # `default` -- the build service reaches the admin API (caddy:2019);
+      # `foundry-preview` -- reach preview containers to reverse-proxy them.
+      - default
+      - foundry-preview
     restart: unless-stopped
 
 volumes:

--- a/docker/foundry-builder/README.md
+++ b/docker/foundry-builder/README.md
@@ -30,8 +30,9 @@ afterwards.
   no plugins, no auto-push, no human gate, no local-model routing, sandbox off)
   and writes it into the bind-mounted working tree. `entrypoint.sh` requires it.
 - **Auth via the proxy** — the container receives `ANTHROPIC_BASE_URL` (the
-  daemon's auth proxy) and a per-build scoped token as `ANTHROPIC_API_KEY`,
-  never the real key.
+  daemon's auth proxy) and a per-build scoped token as `ANTHROPIC_AUTH_TOKEN`
+  (so the `claude` CLI presents it as `Authorization: Bearer`, the header the
+  proxy validates), never the real key.
 
 The entrypoint then `git init`s the working tree, requires `SPEC.md` +
 `TASKS.md`, and `exec`s `foundry run --no-tui --output-format json-stream`.

--- a/docker/foundry-builder/entrypoint.sh
+++ b/docker/foundry-builder/entrypoint.sh
@@ -23,8 +23,10 @@ command -v claude  >/dev/null 2>&1 || { echo "fatal: claude CLI not on PATH" >&2
 command -v foundry >/dev/null 2>&1 || { echo "fatal: foundry not on PATH"   >&2; exit 1; }
 
 # ── Auth must arrive as the per-build proxy token, never the real key ────────
+# The token is delivered as ANTHROPIC_AUTH_TOKEN so the `claude` CLI sends it
+# as `Authorization: Bearer` — the header the auth proxy validates.
 : "${ANTHROPIC_BASE_URL:?fatal: ANTHROPIC_BASE_URL (auth proxy) not set}"
-: "${ANTHROPIC_API_KEY:?fatal: ANTHROPIC_API_KEY (scoped proxy token) not set}"
+: "${ANTHROPIC_AUTH_TOKEN:?fatal: ANTHROPIC_AUTH_TOKEN (scoped proxy token) not set}"
 
 # ── Pinned service git identity ──────────────────────────────────────────────
 git config --global user.name  "Context Foundry Service"

--- a/docs/PLAN_build-service-401-fix.md
+++ b/docs/PLAN_build-service-401-fix.md
@@ -1,0 +1,101 @@
+# Plan: Build-service auth-proxy 401 fix
+
+Date: 2026-05-17
+Version: v1
+Status: in-progress
+
+## Context
+
+VPS deploy of `foundry serve` (local_docker backend, OAuth subscription mode).
+The smoke build fails: every Claude call in the builder container returns
+`401 proxy request denied`, so every task silently completes as WIP with
+`$0.00` cost.
+
+## Current State
+
+- `foundry serve` is deployed and healthy (oauth mode, guard PASS).
+- The storage-wiring defect is already fixed (host-shared bind mount, service
+  runs as uid 10001:994).
+- Root cause of the 401: header mismatch at the builder->proxy boundary.
+  - `src/service/proxy.rs` `messages_handler` reads the inbound per-build
+    token from the `Authorization: Bearer` header only.
+  - `src/service/localdocker.rs` `docker_run_argv` injects the per-build token
+    into the builder as `ANTHROPIC_API_KEY`; the `claude` CLI sends
+    `ANTHROPIC_API_KEY` in the `x-api-key` header, never `Authorization`.
+  - Proxy sees an empty token -> `ProxyDenial::Unauthorized` -> 401.
+
+## Implementation Steps
+
+- [ ] localdocker.rs `docker_run_argv`: inject the per-build token as
+      `ANTHROPIC_AUTH_TOKEN` instead of `ANTHROPIC_API_KEY` (the `claude` CLI
+      sends `ANTHROPIC_AUTH_TOKEN` as `Authorization: Bearer`). Keep
+      `ANTHROPIC_BASE_URL`. Update the doc comment.
+- [ ] localdocker.rs unit test `docker_run_argv_injects_proxy_mount_and_caps`:
+      assert `ANTHROPIC_AUTH_TOKEN=fb_tok`.
+- [ ] docker/foundry-builder/entrypoint.sh: require `ANTHROPIC_AUTH_TOKEN`
+      instead of `ANTHROPIC_API_KEY` (keep the `ANTHROPIC_BASE_URL` check).
+- [ ] Rebuild `foundry-builder:latest` (entrypoint changed).
+- [ ] Recompile + redeploy `foundry-service` (`docker compose up -d --build`).
+- [ ] Guard PASS before/after; re-run the smoke build.
+- [ ] Confirm the job reaches `ready` with non-zero `cost_usd`.
+
+## Architecture Decisions
+
+- Keep the per-build-token + auth-proxy architecture (no token copy, no
+  `~/.claude` bind-mount) -- per explicit instruction.
+- Use `ANTHROPIC_AUTH_TOKEN`, not `CLAUDE_CODE_OAUTH_TOKEN`: the per-build
+  token is an opaque random string, not an Anthropic OAuth-format token;
+  `ANTHROPIC_AUTH_TOKEN` is the format-agnostic bearer var.
+
+## Follow-on defects (found while verifying the fix)
+
+Fixing the 401 (confirmed: auth validates, build logged `[cost] $0.02`)
+surfaced further proxy defects that block a clean `ready`:
+
+- **Output-token damper too low.** `FOUNDRY_SERVICE_PROXY_MAX_OUTPUT_TOKENS`
+  default 8192 < the `max_tokens` the `claude` CLI requests for Opus/Sonnet ->
+  `ProxyDenial::OutputTokensTooHigh` 400. Fixed via `.env` (64000).
+- **Concurrency damper too low.** `FOUNDRY_SERVICE_PROXY_MAX_CONCURRENT`
+  default 8 < a Claude Code build's in-flight burst -> `too_many_concurrent`.
+  Fixed via `.env` (64).
+- **`anthropic-beta` header dropped.** `proxy.rs` `messages_handler` rebuilt
+  the upstream request from scratch and forwarded only its own
+  `oauth-2025-04-20` beta header, discarding the client's `anthropic-beta`.
+  Claude Code's `context_management` body field then failed upstream with
+  `400 "Extra inputs are not permitted"`. Fixed in code: `merge_anthropic_beta`
+  combines the inbound + upstream beta tokens (de-duplicated) into one header.
+- **Preview image ref not lowercased.** `preview_image_ref` built a Docker
+  image tag from the job ID, but job IDs are `fj_` + an (uppercase) ULID, and
+  Docker image repository names must be lowercase -> `docker build -t`
+  rejected the tag instantly, failing the job with `preview_deploy_failed`
+  *after* a fully successful build (audit pass, cost ~$1.63, 2/2 tasks).
+  Fixed in code: `preview_image_ref` lowercases the sanitized component.
+  (Container names are exempt from the lowercase rule and are unchanged.)
+- **#7 — preview unreachable: `--internal` network vs published port.**
+  `preview_run_argv` published a host port (`-p 127.0.0.1::8080`) and
+  `read_preview_port` read it back via `docker port`, but the preview network
+  is `--internal` and Docker does not publish host ports on internal
+  networks. Even if it did, the containerised `foundry-service` has its own
+  loopback. Fixed: dropped `-p` / `read_preview_port` / `port_argv`; the
+  service reaches the preview by container name on the shared `foundry-preview`
+  network (`foundry-service` now joins that network via compose). Also
+  `caddy.rs preview_hostname` now uses `app_name` -> `<app_name>.knowmler.com`
+  (D5 in `SPEC_knowmler-build-integration.md`).
+- **#8 — success path tore down the live preview.** On a job reaching
+  `ready`, `worker.rs` called `cleanup` -> `LocalDocker::teardown`, which
+  `docker rm -f`s the build container *and the preview container* and removes
+  the Caddy route. Correct for failure paths; wrong on success — it destroyed
+  the preview the instant the job went `ready`. (Latent until #7 was fixed:
+  earlier builds failed before `ready`, so `cleanup` only ran on failure
+  paths.) Fixed: the success path releases only the proxy token + storage
+  grant; `teardown` is not called (the build container is `--rm`, already
+  gone; the preview + route must survive).
+
+## Risks & Open Questions
+
+- `ANTHROPIC_AUTH_TOKEN` -> `Authorization: Bearer` confirmed working (denials
+  moved past the auth check; non-zero cost observed).
+- Host subscription must stay untouched (guard PASS before/after).
+- `azure_aca.rs` has the identical `ANTHROPIC_API_KEY` defect for the Azure
+  backend -- pinned with a `TODO(auth-401)` at the call site, not fixed
+  (out of scope; behind the `azure` feature flag).

--- a/docs/PLAN_per-org-preview-domain.md
+++ b/docs/PLAN_per-org-preview-domain.md
@@ -1,0 +1,68 @@
+# Plan: Per-org preview base domain
+Date: 2026-05-17
+Version: v1
+Status: completed -- `cargo check` clean, 68 service unit tests pass
+
+## Context
+Context Foundry previews are served at `<app_name>.<base_domain>`, where
+`base_domain` is one global config value (`FOUNDRY_SERVICE_PREVIEW_DOMAIN`).
+Knowmler wants previews namespaced per organization:
+`<app_name>.<org_slug>.knowmler.com`. The build service must therefore accept
+an org slug per job and compose the preview hostname from it. See the knowmler
+repo's `docs/PLAN_foundry-preview-subdomains.md`.
+
+## Design
+Knowmler passes an optional `org_slug` on `POST /v1/jobs`. The service keeps
+`preview_base_domain` as the ROOT domain (server config, not caller input) and
+composes the effective hostname:
+- `org_slug` present -> `<app_name>.<org_slug>.<root>`
+- `org_slug` absent  -> `<app_name>.<root>` (unchanged; backward compatible)
+
+The caller controls only the `org_slug` segment, validated as a DNS label
+(same rule as `app_name`). It cannot redirect previews to an arbitrary domain.
+
+## Current State (verified 2026-05-17)
+- `caddy.rs`: `preview_hostname(app_name, base_domain)` /
+  `preview_url(app_name, base_domain)`.
+- `localdocker.rs::deploy_preview` (lines 732, 779) calls both with
+  `self.preview.base_domain`.
+- `SubmitRequest` and `Job` (`models.rs`) have no org field.
+- `jobs` table (`migrations/0001_init.sql`) has no org column;
+  `db.rs::row_to_job` maps every column via `SELECT *`.
+- `db.rs::app_name_in_use` checks `app_name` GLOBALLY.
+- `normalized_request_hash` hashes `(app_name, spec_md, tasks_md, ttl)`.
+- No `tests/` integration test touches these symbols; the change is contained
+  to `src/service/`.
+
+## Implementation Steps
+- [x] 1. `migrations/0002_add_org_slug.sql`: `ALTER TABLE jobs ADD COLUMN
+      org_slug TEXT;` (nullable) + index `(app_name, org_slug)`.
+- [x] 2. `models.rs`: add `org_slug: Option<String>` to `SubmitRequest` and
+      `Job`; add `org_slug` to `normalized_request_hash`; validate `org_slug`
+      in `validate_submit` (DNS label). Update unit tests.
+- [x] 3. `caddy.rs`: `preview_hostname` / `preview_url` take
+      `org_slug: Option<&str>` and a `root_domain`. Update doc + tests.
+- [x] 4. `db.rs`: map `org_slug` in `row_to_job`; add it to `insert_job` and
+      `insert_job_capped`; `app_name_in_use` gains `org_slug` and scopes with
+      `org_slug IS NOT DISTINCT FROM $2`.
+- [x] 5. `api.rs`: thread `org_slug` through `submit_job` (hash, conflict
+      check, `Job` construction); add `org_slug` to `JobView`.
+- [x] 6. `localdocker.rs::deploy_preview`: pass `job.org_slug.as_deref()`.
+- [x] 7. `cargo check` + `cargo test` (service module).
+
+## Architecture Decisions
+- Caller passes `org_slug`, NOT a full base domain: the root domain stays
+  server-controlled, so a caller cannot point a preview at an arbitrary host.
+- `org_slug` reuses the `valid_app_name` DNS-label rule.
+- Backward compatible: a request without `org_slug` behaves exactly as today.
+- The `app_name` collision guard becomes per-org (two orgs may reuse a name);
+  for org-less jobs (`NULL`) behavior is unchanged.
+
+## Risks & Open Questions
+- `org_slug` is added to the idempotency hash, so an idempotency_key reused
+  with a different org correctly conflicts.
+- `normalized_request_hash` conflates `None` and `Some("")`; safe in practice
+  because `validate_submit` rejects an empty `org_slug` before the hash.
+- This is a separate repo from knowmler; deploy/version coordination needed.
+- Knowmler's build-submission code must start sending `org_slug` (separate,
+  later task in the knowmler repo).

--- a/docs/SPEC_knowmler-build-integration.md
+++ b/docs/SPEC_knowmler-build-integration.md
@@ -1,0 +1,159 @@
+# SPEC: Knowmler → Context Foundry Build Integration
+
+Date: 2026-05-17
+Status: draft — round-1 decisions locked; backlog + open items noted
+Owner: snedea
+
+## Why this exists — the weight
+
+A *promoted* idea in Knowmler is not a guess. It is an idea a user articulated,
+an AI-built `index.html` mockup the user **liked**, a prototype the community
+**voted up**, and a ranking that **promoted** it to the top. By the time an
+admin builds it, market risk is already retired: demand is validated and the
+visual target is proven.
+
+Consequence for design: the build that follows is not a speculative experiment.
+It earns a real engineering pipeline, a real repo, and real hosting. The
+`index.html` mockup is unusually high-signal context — most builds start from a
+prose guess; this one starts from a prototype the audience already endorsed.
+
+## End-to-end flow
+
+```
+Knowmler "lab"
+  user submits idea (by hand or AI-chat, four questions)
+    → AI builds index.html mockup → hosted (S3 today)
+  community votes → idea reaches "promoted"
+
+Admin opens a promoted idea → "Build with Context Foundry"
+  → dialog: confirms a full-stack build (~20–60 min); picks complexity S/M/L
+  → Knowmler assembles SPEC.md (idea answers + mockup) and TASKS.md
+  → user reviews / edits SPEC.md + TASKS.md            ← pre-build gate
+  → Knowmler calls POST /v1/jobs { spec_md, tasks_md, ... }
+  → Context Foundry build service builds the full-stack app
+  → outputs: a running preview URL  +  a GitHub repo (source + SPEC.md)
+  → user polls progress, then receives the live app + the repo
+```
+
+The build *engine* already exists and is proven: `foundry serve` runs on the
+Claude subscription (OAuth), and the `/v1` contract is shipped and tested. The
+"Build with Context Foundry" button is, mechanically, `POST /v1/jobs`.
+
+## Locked decisions (round 1)
+
+### D1 — Knowmler owns SPEC + TASKS; both user-editable before the build
+
+- Knowmler assembles **both** `SPEC.md` and `TASKS.md`.
+- Both are shown to the end user and are **editable before the build starts**.
+- Rationale: task decomposition encodes Knowmler's identity and guardrails;
+  keeping it in Knowmler means tweaking a guardrail never requires recompiling
+  the Foundry binary. `/v1/jobs` already requires `tasks_md`, so this needs
+  **no Foundry API change** — and it removes the need for any "spec-only mode".
+- Refinement: Knowmler's decomposition must follow Foundry's task-composition
+  rules ([`task-composition.md`](task-composition.md)) — one mental model per
+  task — or the pipeline thrashes. Knowmler owns the initial *shape*; Foundry's
+  PLAN stage refines *within* each task.
+
+### D2 — SPEC.md content
+
+`SPEC.md` must carry both signal sources:
+
+- the user's original answers to the four idea questions (hand-entered or
+  AI-assisted), and
+- the promoted `index.html` mockup — **embedded inline, or referenced by its
+  hosted URL** (the mockup is the visual contract; HTML is context).
+
+### D3 — GitHub is the deliverable home
+
+- The built full-stack app's source is exported to a **GitHub repo**.
+- The original mockup preview URL is (a) recorded in the repo and (b) fed into
+  `SPEC.md`'s context. `SPEC.md` is committed into the repo, so the repo is
+  self-documenting: idea → mockup → tasks → built code.
+- v1 uses a **Context-Foundry-owned GitHub org/account** (one service-level
+  auth); commits are authored as "Context Foundry". Per-user GitHub routing is
+  deferred — see B1.
+
+### D4 — Preview hosting
+
+- The idea-stage mockup stays a static `index.html` (S3 today) — unchanged.
+- A Context Foundry build is a **full-stack app**: its preview is a running
+  container behind a reverse proxy, not a static page. This depends on the
+  `foundry serve` preview subsystem — see Open Items O1.
+
+### D5 — Preview URL scheme
+
+- Preview URLs live under **`*.knowmler.com`**.
+- The subdomain is a **playful, app-derived slug** — e.g.
+  `wishful-stickers.knowmler.com` for a sticker app,
+  `intelligent-feedback.knowmler.com` for a feedback app. Always inclusive,
+  never offensive, in the spirit of Knowmler usernames.
+- **Knowmler generates the slug** from the app (consistent with D1 — Knowmler
+  owns identity/naming) and passes it as the `/v1` `app_name` field, which is
+  already an `[a-z0-9-]` slug. Foundry's preview hostname becomes
+  `<app_name>.knowmler.com` (today it is `build-<job_id>.<domain>` — `caddy.rs`
+  `preview_hostname` must change to use `app_name`).
+- `knowmler.com` is already a homelab-Caddy domain with Cloudflare DNS+TLS, so
+  a `*.knowmler.com` wildcard cert is obtainable via the existing Cloudflare
+  DNS challenge.
+
+## Responsibility split (two repos)
+
+| Knowmler | Context Foundry |
+|----------|-----------------|
+| "Build with Context Foundry" admin button | `/v1` build service (done) |
+| Build dialog: complexity S/M/L + time estimate | builds the app |
+| `SPEC.md` + `TASKS.md` assembly from idea + mockup | GitHub export of source |
+| SPEC/TASKS editor UI (pre-build gate) | preview hosting |
+| Progress UI (polls `GET /v1/jobs/{id}`) | — |
+
+## Backlog / deferred
+
+### B1 — Per-user GitHub integration (enhancement)
+
+User account page shows a **GitHub** login state next to the existing Google
+login (logged in / logged out), wired to GitHub OAuth so a user's builds land
+in *their* repos. Significant subsystem (per-user OAuth, `gh` in the builder).
+Deferred — high-level scaffolding only for now; build shortly after v1.
+
+### B2 — Complexity → time/cost control
+
+Build dialog complexity S/M/L maps to a build budget. Provisional targets from
+round-0 discussion: S ≤ 2h, M ~ 2h, L ~ 4h. Needs a `/v1` request field
+(`complexity` or explicit timeout) — the API has none today. Low priority.
+
+## Open items still needing decisions
+
+- **O1 — Preview hosting.** Three parts, all required before a build yields a
+  working `*.knowmler.com` preview URL:
+  1. *Code (Context Foundry):* the preview subsystem has an unresolved defect
+     — preview containers on an `--internal` Docker network cannot publish a
+     host port, so `read_preview_port` fails (see
+     [`PLAN_build-service-401-fix.md`](PLAN_build-service-401-fix.md) follow-on
+     notes). Fix: route to the preview by container name on a shared network
+     instead of a published host port. Also: `caddy.rs preview_hostname` →
+     `<app_name>.knowmler.com` (D5).
+  2. *DNS:* a wildcard `*.knowmler.com` (or `*.preview.knowmler.com`) record
+     pointing at the VPS, on Cloudflare.
+  3. *Reverse proxy:* a `*.knowmler.com` wildcard block in the **homelab
+     Caddy** (production — fronts ~20 domains) that routes each
+     `<app>.knowmler.com` to the matching preview container. The build service
+     registers/removes these routes via Caddy's admin API.
+- **O2 — Mockup transport.** Embed the `index.html` in `spec_md` vs reference
+  it by hosted URL (D2 permits either). Decide based on `spec_md` size limits
+  and whether the builder container has network access to fetch the URL.
+- **O3 — Hosting platform.** S3 today; Azure possible on other deployments.
+  Keep the built-app preview platform-agnostic (the container model is; static
+  mockup hosting is the part that varies).
+
+## Task decomposition (to refine after O1–O3)
+
+High-level, to be split into file-referenced, single-concern tasks per repo:
+
+- Context Foundry: fix the preview subsystem (O1); GitHub export of build
+  source (D3); optional `complexity` field (B2).
+- Knowmler: admin "Build" button + dialog; `SPEC.md`/`TASKS.md` assembly from
+  idea + mockup (D1, D2); pre-build SPEC/TASKS editor; build-progress UI.
+
+Pure-prose vision does not pipeline (see `task-composition.md`). This SPEC is
+the planning artifact; the file-referenced tasks derived from it are what can
+later run through Context Foundry.

--- a/docs/SPEC_knowmler-build-integration.md
+++ b/docs/SPEC_knowmler-build-integration.md
@@ -95,6 +95,19 @@ Claude subscription (OAuth), and the `/v1` contract is shipped and tested. The
 - `knowmler.com` is already a homelab-Caddy domain with Cloudflare DNS+TLS, so
   a `*.knowmler.com` wildcard cert is obtainable via the existing Cloudflare
   DNS challenge.
+- The `preview_url` returned by `/v1` is `https://` — previews are served
+  through a TLS-terminating Caddy; an `http://` URL would mixed-content-fail
+  when consumed from Knowmler's HTTPS pages. (Fixed in `caddy.rs::preview_url`.)
+
+### D6 — Preview hostname uniqueness is Knowmler's responsibility
+
+`app_name` becomes the preview hostname (`<app_name>.knowmler.com`). The `/v1`
+API validates `app_name` for slug *shape* only; there is no uniqueness
+constraint. Two live previews with the same `app_name` collide on the same
+host. **Knowmler must guarantee `app_name` is unique among currently-live
+(`ready`) previews** — regenerate/suffix the playful slug on collision. Open:
+whether the build service should *also* hard-reject a submit whose `app_name`
+matches a live preview (a defence-in-depth guard) — see O5.
 
 ## Responsibility split (two repos)
 
@@ -131,7 +144,9 @@ round-0 discussion: S ≤ 2h, M ~ 2h, L ~ 4h. Needs a `/v1` request field
      [`PLAN_build-service-401-fix.md`](PLAN_build-service-401-fix.md) follow-on
      notes). Fix: route to the preview by container name on a shared network
      instead of a published host port. Also: `caddy.rs preview_hostname` →
-     `<app_name>.knowmler.com` (D5).
+     `<app_name>.knowmler.com` (D5). **DONE — defects #7 (preview network) and
+     #8 (success-path teardown) fixed; PR context-foundry#269. Verified
+     reachable on the VPS-internal network only, not yet externally.**
   2. *DNS:* a wildcard `*.knowmler.com` (or `*.preview.knowmler.com`) record
      pointing at the VPS, on Cloudflare.
   3. *Reverse proxy:* a `*.knowmler.com` wildcard block in the **homelab
@@ -144,8 +159,18 @@ round-0 discussion: S ≤ 2h, M ~ 2h, L ~ 4h. Needs a `/v1` request field
 - **O3 — Hosting platform.** S3 today; Azure possible on other deployments.
   Keep the built-app preview platform-agnostic (the container model is; static
   mockup hosting is the part that varies).
+- **O4 — Embedding the preview in Knowmler (iframe vs link).** If the built
+  app is shown inside an iframe (as the idea-stage S3 mockup is), the
+  `knowmler.com` CSP `frame-src` must add `https://*.knowmler.com`
+  (`caddy2/Caddyfile`) — a production change to bundle with the Caddy work. If
+  the rollout is link-only, no CSP change is needed. **Decide before the
+  production-Caddy change.**
+- **O5 — Service-side slug-collision guard (optional).** D6 makes unique
+  `app_name`s Knowmler's responsibility. Optionally the build service could
+  *also* reject a `/v1` submit whose `app_name` matches a currently-`ready`
+  preview — defence in depth. Decide whether to implement.
 
-## Task decomposition (to refine after O1–O3)
+## Task decomposition (to refine after O1–O5)
 
 High-level, to be split into file-referenced, single-concern tasks per repo:
 

--- a/docs/build-service-api.md
+++ b/docs/build-service-api.md
@@ -190,6 +190,7 @@ Typed JSON errors carry:
 | `unauthorized` | `401` | Missing or invalid bearer token |
 | `not_found` | `404` | Unknown job or missing artifact |
 | `idempotency_conflict` | `409` | `idempotency_key` reused with a different normalized request |
+| `app_name_conflict` | `409` | `app_name` is already held by an in-flight or live (`ready`) build -- the preview hostname would collide; pick a different slug and resubmit |
 | `queue_full` | `429` | Queued job count is at `FOUNDRY_SERVICE_QUEUE_CAP` |
 | `build_timeout` | `500` | Build exceeded the wall-clock timeout |
 | `build_crashed` | `500` | The builder produced no terminal report |

--- a/docs/build-service-preview.md
+++ b/docs/build-service-preview.md
@@ -66,7 +66,12 @@ migration is needed.
 - `--restart on-failure:3` -- a bounded restart policy.
 - `--memory` / `--cpus` / `--pids-limit` -- resource caps.
 - only `-e PORT=8080` -- **no secrets**, no `ANTHROPIC_*` env.
-- `-p 127.0.0.1::8080` -- the host port is published on loopback only.
+
+**No host port is published.** The preview is reached by **container name** on
+the `foundry-preview` network (`foundry-preview-<job>:8080`); the
+`foundry-service` process and the Caddy that fronts previews both join that
+network. Host-port publishing does not work here -- the network is
+`--internal`, and the service runs in its own container with its own loopback.
 
 A health-check failure tears the container down, so a failed deploy leaves
 nothing running.
@@ -75,14 +80,30 @@ nothing running.
 
 `src/service/caddy.rs` POSTs a `reverse_proxy` route to the Caddy admin API at
 `caddy_admin_url`, appending it to the routes of the configured HTTP server
-(`caddy_server_name`, default `srv0`). The preview URL is
-`http://build-<job>.<preview_base_domain>`.
+(`caddy_server_name`, default `srv0`). The route's upstream is the preview
+container by name (`foundry-preview-<job>:8080`); its host match and the
+`preview_url` stored on the job are `https://<app_name>.<preview_base_domain>`
+(`app_name` is the `/v1` request slug). The route `@id` keys off the job id,
+so route registration stays unique even if two jobs share an `app_name` -- but
+the host *match* does not (see "Hostname uniqueness" below).
 
 Route registration is **best-effort**: a Caddy that is down or misconfigured
 logs a warning and the job still reaches `ready`. Only a failed container start
 or a health-check timeout produces `preview_deploy_failed`.
 
 Caddy must already have an HTTP server configured for the route POST to land.
+
+## Hostname uniqueness
+
+The preview hostname is `<app_name>.<domain>`, and the `/v1` API validates
+`app_name` for slug *shape* only -- there is no uniqueness constraint on
+`app_name` in the jobs table. Two live previews with the same `app_name`
+register two Caddy routes (distinct `@id`s) that match the **same** host;
+Caddy serves whichever it resolves first.
+
+The caller (Knowmler) owns naming and **must** keep `app_name` unique among
+currently-live (`ready`) previews -- e.g. by regenerating or suffixing the
+playful slug on collision. See `SPEC_knowmler-build-integration.md` (D5).
 
 ## TTL + teardown
 
@@ -99,7 +120,7 @@ Eight `FOUNDRY_SERVICE_*` env vars tune preview hosting:
 | Env var | Default | Purpose |
 |---------|---------|---------|
 | `FOUNDRY_SERVICE_PREVIEW_NETWORK` | `foundry-preview` | Isolated preview network name |
-| `FOUNDRY_SERVICE_PREVIEW_DOMAIN` | `foundry.local` | Base domain (`build-<job>.<domain>`) |
+| `FOUNDRY_SERVICE_PREVIEW_DOMAIN` | `foundry.local` | Base domain (`<app_name>.<domain>`) |
 | `FOUNDRY_SERVICE_CADDY_ADMIN_URL` | `http://localhost:2019` | Caddy admin API URL |
 | `FOUNDRY_SERVICE_CADDY_SERVER` | `srv0` | Caddy HTTP-server name routes append to |
 | `FOUNDRY_SERVICE_PREVIEW_HEALTH_TIMEOUT_SECS` | `60` | Health-check poll budget |

--- a/migrations/0002_add_org_slug.sql
+++ b/migrations/0002_add_org_slug.sql
@@ -1,0 +1,9 @@
+-- 0002_add_org_slug.sql
+-- Per-org preview namespacing. When a job carries an org_slug, its preview
+-- hostname becomes <app_name>.<org_slug>.<root_domain>; otherwise it stays
+-- <app_name>.<root_domain> (unchanged). Nullable: existing jobs and org-less
+-- `foundry serve` use have no organization.
+ALTER TABLE jobs ADD COLUMN org_slug TEXT;
+
+-- Supports the per-org app_name collision check (db::app_name_in_use).
+CREATE INDEX jobs_app_org ON jobs (app_name, org_slug);

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -211,6 +211,21 @@ async fn submit_job(State(state): State<Arc<AppState>>, body: Bytes) -> Response
         Err(_) => return err(ErrorCode::InternalError, "idempotency lookup failed"),
     }
 
+    // Reject a submit whose app_name is already held by an in-flight or live
+    // preview -- the preview hostname is `<app_name>.<domain>`, so two would
+    // collide on the same host (SPEC O5 / D6). An idempotent replay is handled
+    // above, so this only fires for a genuinely new submit.
+    match db::app_name_in_use(&state.pool, &req.app_name).await {
+        Ok(true) => {
+            return err(
+                ErrorCode::AppNameConflict,
+                "app_name is already in use by an in-flight or live build",
+            )
+        }
+        Ok(false) => {}
+        Err(_) => return err(ErrorCode::InternalError, "app_name conflict check failed"),
+    }
+
     let now = Utc::now();
     let job = Job {
         id: format!("fj_{}", Ulid::new()),

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -48,6 +48,7 @@ struct JobView {
     schema_version: u32,
     job_id: String,
     app_name: String,
+    org_slug: Option<String>,
     owner: String,
     status: String,
     percent: i32,
@@ -120,6 +121,7 @@ async fn job_view(state: &Arc<AppState>, job: &Job) -> JobView {
         schema_version: 1,
         job_id: job.id.clone(),
         app_name: job.app_name.clone(),
+        org_slug: job.org_slug.clone(),
         owner: job.owner.clone(),
         status: job.status.as_str().to_string(),
         percent: job.percent,
@@ -192,8 +194,13 @@ async fn submit_job(State(state): State<Arc<AppState>>, body: Bytes) -> Response
     }
 
     let ttl = models::clamp_ttl(&state.config, req.preview_ttl_hours);
-    let hash =
-        models::normalized_request_hash(&req.app_name, &req.spec_md, &req.tasks_md, ttl);
+    let hash = models::normalized_request_hash(
+        &req.app_name,
+        req.org_slug.as_deref(),
+        &req.spec_md,
+        &req.tasks_md,
+        ttl,
+    );
 
     match db::find_by_idempotency(&state.pool, &req.owner, &req.idempotency_key).await {
         Ok(Some(existing)) => {
@@ -215,7 +222,7 @@ async fn submit_job(State(state): State<Arc<AppState>>, body: Bytes) -> Response
     // preview -- the preview hostname is `<app_name>.<domain>`, so two would
     // collide on the same host (SPEC O5 / D6). An idempotent replay is handled
     // above, so this only fires for a genuinely new submit.
-    match db::app_name_in_use(&state.pool, &req.app_name).await {
+    match db::app_name_in_use(&state.pool, &req.app_name, req.org_slug.as_deref()).await {
         Ok(true) => {
             return err(
                 ErrorCode::AppNameConflict,
@@ -230,6 +237,7 @@ async fn submit_job(State(state): State<Arc<AppState>>, body: Bytes) -> Response
     let job = Job {
         id: format!("fj_{}", Ulid::new()),
         app_name: req.app_name.clone(),
+        org_slug: req.org_slug.clone(),
         owner: req.owner.clone(),
         status: JobStatus::Queued,
         percent: 0,

--- a/src/service/azure_aca.rs
+++ b/src/service/azure_aca.rs
@@ -393,6 +393,15 @@ impl BuildBackend for AzureContainerApps {
                         "resources": { "cpu": 2.0, "memory": "4Gi" },
                         "env": [
                             { "name": "ANTHROPIC_BASE_URL", "value": self.proxy_url },
+                            // TODO(auth-401): inject `proxy_token` as ANTHROPIC_AUTH_TOKEN,
+                            // not ANTHROPIC_API_KEY. The `claude` CLI sends ANTHROPIC_API_KEY
+                            // as the `x-api-key` header, but the auth proxy reads the token
+                            // from `Authorization: Bearer` (`messages_handler` in proxy.rs),
+                            // so every build call is rejected 401 `unauthorized`. This is the
+                            // identical bug fixed for the local_docker backend in
+                            // `localdocker.rs::docker_run_argv` (see the doc comment there).
+                            // The foundry-builder `entrypoint.sh` now also requires
+                            // ANTHROPIC_AUTH_TOKEN. Fix when the Azure backend is exercised.
                             { "name": "ANTHROPIC_API_KEY", "value": proxy_token },
                             { "name": "FOUNDRY_JOB_ID", "value": job.id },
                             { "name": "FOUNDRY_STORAGE_GRANT", "value": grant_sas },

--- a/src/service/caddy.rs
+++ b/src/service/caddy.rs
@@ -29,14 +29,20 @@ pub fn route_id(job_id: &str) -> String {
     format!("foundry-preview-{}", host_label(job_id))
 }
 
-/// The hostname a preview is served under (`build-<job>.<base_domain>`).
-pub fn preview_hostname(job_id: &str, base_domain: &str) -> String {
-    format!("build-{}.{}", host_label(job_id), base_domain)
+/// The hostname a preview is served under (`<app_name>.<base_domain>`).
+///
+/// `app_name` is the `/v1` request field — already validated as a lowercase
+/// `[a-z0-9-]` slug, i.e. a DNS-safe label — so it is used directly. Knowmler
+/// generates a playful, app-derived slug, so a preview lands at e.g.
+/// `wishful-stickers.knowmler.com`. The Caddy route `@id` keys off the job id
+/// (`route_id`), which stays unique even if two apps share a name.
+pub fn preview_hostname(app_name: &str, base_domain: &str) -> String {
+    format!("{}.{}", app_name, base_domain)
 }
 
 /// The full `http://` preview URL stored on the job.
-pub fn preview_url(job_id: &str, base_domain: &str) -> String {
-    format!("http://{}", preview_hostname(job_id, base_domain))
+pub fn preview_url(app_name: &str, base_domain: &str) -> String {
+    format!("http://{}", preview_hostname(app_name, base_domain))
 }
 
 /// The Caddy route object reverse-proxying `hostname` to `upstream`
@@ -108,14 +114,16 @@ mod tests {
 
     #[test]
     fn route_id_and_hostname_are_derived() {
+        // route_id is keyed by the job id (unique); the hostname uses the
+        // app_name slug — the playful, app-derived label Knowmler generates.
         assert_eq!(route_id("fj_1"), "foundry-preview-fj-1");
         assert_eq!(
-            preview_hostname("fj_1", "foundry.local"),
-            "build-fj-1.foundry.local"
+            preview_hostname("wishful-stickers", "knowmler.com"),
+            "wishful-stickers.knowmler.com"
         );
         assert_eq!(
-            preview_url("fj_1", "foundry.local"),
-            "http://build-fj-1.foundry.local"
+            preview_url("wishful-stickers", "knowmler.com"),
+            "http://wishful-stickers.knowmler.com"
         );
     }
 

--- a/src/service/caddy.rs
+++ b/src/service/caddy.rs
@@ -29,15 +29,22 @@ pub fn route_id(job_id: &str) -> String {
     format!("foundry-preview-{}", host_label(job_id))
 }
 
-/// The hostname a preview is served under (`<app_name>.<base_domain>`).
+/// The hostname a preview is served under.
 ///
-/// `app_name` is the `/v1` request field — already validated as a lowercase
-/// `[a-z0-9-]` slug, i.e. a DNS-safe label — so it is used directly. Knowmler
-/// generates a playful, app-derived slug, so a preview lands at e.g.
-/// `wishful-stickers.knowmler.com`. The Caddy route `@id` keys off the job id
-/// (`route_id`), which stays unique even if two apps share a name.
-pub fn preview_hostname(app_name: &str, base_domain: &str) -> String {
-    format!("{}.{}", app_name, base_domain)
+/// With an `org_slug` the preview is namespaced per organization —
+/// `<app_name>.<org_slug>.<root_domain>` — so each org's builds live under
+/// their own subdomain. Without one it is `<app_name>.<root_domain>`
+/// (unchanged, backward compatible). `app_name` and `org_slug` are both
+/// validated lowercase `[a-z0-9-]` slugs (DNS-safe labels), so they are used
+/// directly. Knowmler generates a playful, app-derived `app_name`, so a
+/// preview lands at e.g. `wishful-stickers.acme.knowmler.com`. The Caddy
+/// route `@id` keys off the job id (`route_id`), which stays unique even if
+/// two apps share a name.
+pub fn preview_hostname(app_name: &str, org_slug: Option<&str>, root_domain: &str) -> String {
+    match org_slug {
+        Some(slug) => format!("{}.{}.{}", app_name, slug, root_domain),
+        None => format!("{}.{}", app_name, root_domain),
+    }
 }
 
 /// The full `https://` preview URL stored on the job.
@@ -45,8 +52,8 @@ pub fn preview_hostname(app_name: &str, base_domain: &str) -> String {
 /// `https`, not `http`: previews are always served through a TLS-terminating
 /// reverse proxy (Caddy). Knowmler links/embeds this URL from an HTTPS page,
 /// so an `http://` value would be a mixed-content failure.
-pub fn preview_url(app_name: &str, base_domain: &str) -> String {
-    format!("https://{}", preview_hostname(app_name, base_domain))
+pub fn preview_url(app_name: &str, org_slug: Option<&str>, root_domain: &str) -> String {
+    format!("https://{}", preview_hostname(app_name, org_slug, root_domain))
 }
 
 /// The Caddy route object reverse-proxying `hostname` to `upstream`
@@ -121,13 +128,23 @@ mod tests {
         // route_id is keyed by the job id (unique); the hostname uses the
         // app_name slug — the playful, app-derived label Knowmler generates.
         assert_eq!(route_id("fj_1"), "foundry-preview-fj-1");
+        // No org slug: <app>.<root> (backward compatible).
         assert_eq!(
-            preview_hostname("wishful-stickers", "knowmler.com"),
+            preview_hostname("wishful-stickers", None, "knowmler.com"),
             "wishful-stickers.knowmler.com"
         );
         assert_eq!(
-            preview_url("wishful-stickers", "knowmler.com"),
+            preview_url("wishful-stickers", None, "knowmler.com"),
             "https://wishful-stickers.knowmler.com"
+        );
+        // With an org slug: <app>.<org>.<root>.
+        assert_eq!(
+            preview_hostname("wishful-stickers", Some("acme"), "knowmler.com"),
+            "wishful-stickers.acme.knowmler.com"
+        );
+        assert_eq!(
+            preview_url("wishful-stickers", Some("acme"), "knowmler.com"),
+            "https://wishful-stickers.acme.knowmler.com"
         );
     }
 

--- a/src/service/caddy.rs
+++ b/src/service/caddy.rs
@@ -40,9 +40,13 @@ pub fn preview_hostname(app_name: &str, base_domain: &str) -> String {
     format!("{}.{}", app_name, base_domain)
 }
 
-/// The full `http://` preview URL stored on the job.
+/// The full `https://` preview URL stored on the job.
+///
+/// `https`, not `http`: previews are always served through a TLS-terminating
+/// reverse proxy (Caddy). Knowmler links/embeds this URL from an HTTPS page,
+/// so an `http://` value would be a mixed-content failure.
 pub fn preview_url(app_name: &str, base_domain: &str) -> String {
-    format!("http://{}", preview_hostname(app_name, base_domain))
+    format!("https://{}", preview_hostname(app_name, base_domain))
 }
 
 /// The Caddy route object reverse-proxying `hostname` to `upstream`
@@ -123,7 +127,7 @@ mod tests {
         );
         assert_eq!(
             preview_url("wishful-stickers", "knowmler.com"),
-            "http://wishful-stickers.knowmler.com"
+            "https://wishful-stickers.knowmler.com"
         );
     }
 

--- a/src/service/db.rs
+++ b/src/service/db.rs
@@ -36,6 +36,7 @@ fn row_to_job(row: &PgRow) -> Job {
     Job {
         id: row.get("id"),
         app_name: row.get("app_name"),
+        org_slug: row.get("org_slug"),
         owner: row.get("owner"),
         status,
         percent: row.get("percent"),
@@ -76,17 +77,26 @@ pub async fn find_by_idempotency(
     Ok(row.as_ref().map(row_to_job))
 }
 
-/// Returns `true` when an in-flight or live-preview job already holds
-/// `app_name` -- i.e. a job in `queued`, `building`, `deploying`, or `ready`.
-/// The preview hostname is `<app_name>.<domain>`, so two such jobs would
-/// collide on the same host; the submit path rejects the second (SPEC O5).
-pub async fn app_name_in_use(pool: &PgPool, app_name: &str) -> Result<bool> {
+/// Returns `true` when an in-flight or live-preview job in the SAME org
+/// already holds `app_name` -- i.e. a job in `queued`, `building`,
+/// `deploying`, or `ready`. The preview hostname is
+/// `<app_name>.<org_slug>.<domain>`, so a collision is per-org: two orgs may
+/// reuse a name freely. `org_slug` is matched with `IS NOT DISTINCT FROM`, so
+/// a `NULL` (org-less) job collides only with other `NULL` jobs. The submit
+/// path rejects a second colliding job (SPEC O5).
+pub async fn app_name_in_use(
+    pool: &PgPool,
+    app_name: &str,
+    org_slug: Option<&str>,
+) -> Result<bool> {
     let count: i64 = sqlx::query_scalar::<_, i64>(
         "SELECT count(*) FROM jobs \
          WHERE app_name = $1 \
+         AND org_slug IS NOT DISTINCT FROM $2 \
          AND status IN ('queued', 'building', 'deploying', 'ready')",
     )
     .bind(app_name)
+    .bind(org_slug)
     .fetch_one(pool)
     .await
     .context("check app_name in use")?;
@@ -120,8 +130,8 @@ pub async fn count_queued(pool: &PgPool) -> Result<i64> {
 pub async fn insert_job(pool: &PgPool, job: &Job) -> Result<bool> {
     let result = sqlx::query(
         "INSERT INTO jobs \
-         (id, app_name, owner, status, percent, spec_md, tasks_md, cost_usd, ttl_hours, idempotency_key, request_hash) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+         (id, app_name, owner, status, percent, spec_md, tasks_md, cost_usd, ttl_hours, idempotency_key, request_hash, org_slug) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
     )
     .bind(job.id.as_str())
     .bind(job.app_name.as_str())
@@ -134,6 +144,7 @@ pub async fn insert_job(pool: &PgPool, job: &Job) -> Result<bool> {
     .bind(job.ttl_hours)
     .bind(job.idempotency_key.as_str())
     .bind(job.request_hash.as_str())
+    .bind(job.org_slug.as_deref())
     .execute(pool)
     .await;
 
@@ -182,8 +193,8 @@ pub async fn insert_job_capped(
     }
     let result = sqlx::query(
         "INSERT INTO jobs \
-         (id, app_name, owner, status, percent, spec_md, tasks_md, cost_usd, ttl_hours, idempotency_key, request_hash) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+         (id, app_name, owner, status, percent, spec_md, tasks_md, cost_usd, ttl_hours, idempotency_key, request_hash, org_slug) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
     )
     .bind(job.id.as_str())
     .bind(job.app_name.as_str())
@@ -196,6 +207,7 @@ pub async fn insert_job_capped(
     .bind(job.ttl_hours)
     .bind(job.idempotency_key.as_str())
     .bind(job.request_hash.as_str())
+    .bind(job.org_slug.as_deref())
     .execute(&mut *tx)
     .await;
 

--- a/src/service/db.rs
+++ b/src/service/db.rs
@@ -76,6 +76,23 @@ pub async fn find_by_idempotency(
     Ok(row.as_ref().map(row_to_job))
 }
 
+/// Returns `true` when an in-flight or live-preview job already holds
+/// `app_name` -- i.e. a job in `queued`, `building`, `deploying`, or `ready`.
+/// The preview hostname is `<app_name>.<domain>`, so two such jobs would
+/// collide on the same host; the submit path rejects the second (SPEC O5).
+pub async fn app_name_in_use(pool: &PgPool, app_name: &str) -> Result<bool> {
+    let count: i64 = sqlx::query_scalar::<_, i64>(
+        "SELECT count(*) FROM jobs \
+         WHERE app_name = $1 \
+         AND status IN ('queued', 'building', 'deploying', 'ready')",
+    )
+    .bind(app_name)
+    .fetch_one(pool)
+    .await
+    .context("check app_name in use")?;
+    Ok(count > 0)
+}
+
 /// Fixed advisory-lock key serializing every queue-cap capacity decision.
 const QUEUE_CAP_LOCK_KEY: i64 = 7_345_201;
 

--- a/src/service/localdocker.rs
+++ b/src/service/localdocker.rs
@@ -201,8 +201,15 @@ pub fn container_name(job_id: &str) -> String {
 }
 
 /// The deterministic image tag for a job's preview app image.
+///
+/// Docker image repository names must be lowercase. Job IDs are `fj_` + a
+/// ULID, and ULIDs are uppercase — so the component is lowercased here.
+/// Container names (above) have no such rule and keep their original case.
 pub fn preview_image_ref(job_id: &str) -> String {
-    format!("foundry-preview-{}:latest", sanitize_component(job_id))
+    format!(
+        "foundry-preview-{}:latest",
+        sanitize_component(job_id).to_ascii_lowercase()
+    )
 }
 
 /// The deterministic container name for a job's preview container.
@@ -469,8 +476,14 @@ impl LocalDocker {
 
     /// Render the `docker run` argument vector (everything after the docker
     /// binary). Injects `ANTHROPIC_BASE_URL` → the auth proxy, the per-build
-    /// scoped token as `ANTHROPIC_API_KEY`, the per-job bind mount, and coarse
-    /// CPU/memory/pids resource caps.
+    /// scoped token as `ANTHROPIC_AUTH_TOKEN`, the per-job bind mount, and
+    /// coarse CPU/memory/pids resource caps.
+    ///
+    /// The token is injected as `ANTHROPIC_AUTH_TOKEN` (not `ANTHROPIC_API_KEY`)
+    /// so the `claude` CLI sends it in the `Authorization: Bearer` header — the
+    /// header the auth proxy reads (`messages_handler` in `proxy.rs`). An
+    /// `ANTHROPIC_API_KEY` would instead go out as `x-api-key` and the proxy
+    /// would reject the request as unauthorized.
     pub fn docker_run_argv(&self, job_id: &str, work_dir: &Path, proxy_token: &str) -> Vec<String> {
         vec![
             "run".to_string(),
@@ -480,7 +493,7 @@ impl LocalDocker {
             "-e".to_string(),
             format!("ANTHROPIC_BASE_URL={}", self.proxy_url),
             "-e".to_string(),
-            format!("ANTHROPIC_API_KEY={proxy_token}"),
+            format!("ANTHROPIC_AUTH_TOKEN={proxy_token}"),
             "--add-host".to_string(),
             "host.docker.internal:host-gateway".to_string(),
             "--memory".to_string(),
@@ -562,38 +575,12 @@ impl LocalDocker {
             self.preview.pids_limit.to_string(),
             "-e".to_string(),
             format!("PORT={}", self.preview.container_port),
-            "-p".to_string(),
-            format!("127.0.0.1::{}", self.preview.container_port),
+            // No `-p` host-port publish: the preview is reached by container
+            // name on the shared `foundry-preview` network. Publishing a port
+            // does not work here anyway — the network is `--internal`, and the
+            // service runs in its own container with its own loopback.
             image_ref.to_string(),
         ]
-    }
-
-    /// The `docker port` argv that reports the host port a preview is on.
-    pub fn port_argv(&self, job_id: &str) -> Vec<String> {
-        vec![
-            "port".to_string(),
-            preview_container_name(job_id),
-            format!("{}/tcp", self.preview.container_port),
-        ]
-    }
-
-    /// Read the ephemeral host port Docker assigned to a preview container.
-    async fn read_preview_port(&self, job_id: &str) -> Result<u16> {
-        let out = tokio::process::Command::new(&self.docker_bin)
-            .args(self.port_argv(job_id))
-            .stdin(Stdio::null())
-            .output()
-            .await
-            .with_context(|| format!("docker port for preview {job_id}"))?;
-        if !out.status.success() {
-            anyhow::bail!("docker port failed for preview {job_id}");
-        }
-        let text = String::from_utf8_lossy(&out.stdout);
-        text.lines()
-            .filter_map(|l| l.rsplit(':').next())
-            .filter_map(|p| p.trim().parse::<u16>().ok())
-            .next()
-            .with_context(|| format!("parse host port from `{}`", text.trim()))
     }
 
     /// Run one `docker build`, teeing stdout/stderr to `logs/image-build.log`.
@@ -742,7 +729,7 @@ impl BuildBackend for LocalDocker {
     }
 
     async fn deploy_preview(&self, job: &Job, image: &ImageRef) -> Result<PreviewInfo> {
-        let url = caddy::preview_url(&job.id, &self.preview.base_domain);
+        let url = caddy::preview_url(&job.app_name, &self.preview.base_domain);
 
         // Test seam: a recorded build never produced a real image to run.
         if self.recorded_stream.is_some() {
@@ -771,8 +758,14 @@ impl BuildBackend for LocalDocker {
             anyhow::bail!("preview container for job {} failed to start", job.id);
         }
 
-        let host_port = self.read_preview_port(&job.id).await?;
-        let upstream = format!("127.0.0.1:{host_port}");
+        // The preview is reached by container name on the shared
+        // `foundry-preview` network — the service and the reverse proxy both
+        // join it. No host port is published (see `preview_run_argv`).
+        let upstream = format!(
+            "{}:{}",
+            preview_container_name(&job.id),
+            self.preview.container_port
+        );
 
         // Health-check; on failure tear the container down so a failed deploy
         // leaves nothing running.
@@ -783,7 +776,7 @@ impl BuildBackend for LocalDocker {
 
         // Register the Caddy route — best-effort: a missing/misconfigured
         // Caddy logs a warning but must NOT fail the job.
-        let hostname = caddy::preview_hostname(&job.id, &self.preview.base_domain);
+        let hostname = caddy::preview_hostname(&job.app_name, &self.preview.base_domain);
         if let Err(e) = caddy::add_route(
             &self.preview.caddy_admin_url,
             &self.preview.caddy_server_name,
@@ -948,7 +941,7 @@ mod tests {
         assert_eq!(argv[0], "run");
         assert!(argv.contains(&"--rm".to_string()));
         assert!(argv.contains(&"ANTHROPIC_BASE_URL=http://host.docker.internal:8788".to_string()));
-        assert!(argv.contains(&"ANTHROPIC_API_KEY=fb_tok".to_string()));
+        assert!(argv.contains(&"ANTHROPIC_AUTH_TOKEN=fb_tok".to_string()));
         assert!(argv.contains(&"/srv/storage/jobs/fj_1/work:/work".to_string()));
         assert!(argv.contains(&"--pids-limit".to_string()));
         assert!(argv.contains(&"4g".to_string()), "default build memory cap");
@@ -1014,10 +1007,13 @@ mod tests {
 
     #[test]
     fn preview_image_ref_and_name_are_safe() {
+        // The image ref must be lowercased: job IDs are uppercase ULIDs but
+        // Docker rejects an image repository name that is not lowercase.
         assert_eq!(
             preview_image_ref("fj_01HMX"),
-            "foundry-preview-fj_01HMX:latest"
+            "foundry-preview-fj_01hmx:latest"
         );
+        // Container names have no lowercase rule and keep their case.
         assert_eq!(
             preview_container_name("a/b c"),
             "foundry-preview-a-b-c"
@@ -1074,7 +1070,6 @@ mod tests {
             "256",
             "-e",
             "PORT=8080",
-            "127.0.0.1::8080",
         ] {
             assert!(
                 argv.contains(&expected.to_string()),
@@ -1083,6 +1078,8 @@ mod tests {
         }
         assert!(!argv.iter().any(|a| a.contains("ANTHROPIC")));
         assert!(!argv.iter().any(|a| a.contains("sk-ant")));
+        // No host-port publish — the preview is reached by container name.
+        assert!(!argv.iter().any(|a| a == "-p"));
     }
 
     #[test]

--- a/src/service/localdocker.rs
+++ b/src/service/localdocker.rs
@@ -729,7 +729,11 @@ impl BuildBackend for LocalDocker {
     }
 
     async fn deploy_preview(&self, job: &Job, image: &ImageRef) -> Result<PreviewInfo> {
-        let url = caddy::preview_url(&job.app_name, &self.preview.base_domain);
+        let url = caddy::preview_url(
+            &job.app_name,
+            job.org_slug.as_deref(),
+            &self.preview.base_domain,
+        );
 
         // Test seam: a recorded build never produced a real image to run.
         if self.recorded_stream.is_some() {
@@ -776,7 +780,11 @@ impl BuildBackend for LocalDocker {
 
         // Register the Caddy route — best-effort: a missing/misconfigured
         // Caddy logs a warning but must NOT fail the job.
-        let hostname = caddy::preview_hostname(&job.app_name, &self.preview.base_domain);
+        let hostname = caddy::preview_hostname(
+            &job.app_name,
+            job.org_slug.as_deref(),
+            &self.preview.base_domain,
+        );
         if let Err(e) = caddy::add_route(
             &self.preview.caddy_admin_url,
             &self.preview.caddy_server_name,

--- a/src/service/models.rs
+++ b/src/service/models.rs
@@ -167,6 +167,8 @@ impl ErrorCode {
 pub struct Job {
     pub id: String,
     pub app_name: String,
+    /// Organization slug; namespaces the preview hostname when set.
+    pub org_slug: Option<String>,
     pub owner: String,
     pub status: JobStatus,
     pub percent: i32,
@@ -200,6 +202,10 @@ pub struct SubmitRequest {
     pub owner: String,
     pub preview_ttl_hours: Option<i32>,
     pub idempotency_key: String,
+    /// Optional organization slug. When present, the preview is namespaced
+    /// per org: `<app_name>.<org_slug>.<root_domain>`. A missing or null
+    /// field deserializes to `None` (backward compatible).
+    pub org_slug: Option<String>,
 }
 
 // ─── Validation + idempotency ───────────────────────────────────────────────
@@ -229,16 +235,21 @@ pub fn clamp_ttl(cfg: &ServiceConfig, requested: Option<i32>) -> i32 {
 ///
 /// The TTL component is the SERVER-CLAMPED value, so two requests whose raw
 /// `preview_ttl_hours` differ but clamp identically produce the same hash.
+/// `org_slug` is included so an `idempotency_key` reused with a different org
+/// (a different preview hostname) is treated as a changed request; a `None`
+/// slug hashes as the empty string, and `validate_submit` never admits an
+/// empty slug as present, so `None` and `Some("")` cannot collide in practice.
 /// Fields are separated by a `0x1e` record-separator byte so concatenation
 /// ambiguity cannot collide distinct inputs.
 pub fn normalized_request_hash(
     app_name: &str,
+    org_slug: Option<&str>,
     spec_md: &str,
     tasks_md: &str,
     clamped_ttl: i32,
 ) -> String {
     let mut hasher = blake3::Hasher::new();
-    for field in [app_name, spec_md, tasks_md] {
+    for field in [app_name, org_slug.unwrap_or(""), spec_md, tasks_md] {
         hasher.update(field.as_bytes());
         hasher.update(&[0x1e]);
     }
@@ -294,6 +305,16 @@ pub fn validate_submit(cfg: &ServiceConfig, req: &SubmitRequest) -> Result<(), S
     if req.idempotency_key.is_empty() {
         return Err("idempotency_key must not be empty".to_string());
     }
+    // An org slug becomes a DNS label in the preview hostname
+    // (`<app_name>.<org_slug>.<root>`), so it has the same shape rule as
+    // `app_name`. Absent is fine -- the preview is then un-namespaced.
+    if let Some(slug) = &req.org_slug {
+        if !valid_app_name(slug) {
+            return Err(
+                "org_slug must be a non-empty [a-z0-9-] slug not bordered by '-'".to_string(),
+            );
+        }
+    }
     Ok(())
 }
 
@@ -344,6 +365,37 @@ mod tests {
         }
     }
 
+    fn submit_req() -> SubmitRequest {
+        SubmitRequest {
+            app_name: "recipe-finder".to_string(),
+            spec_md: "spec".to_string(),
+            tasks_md: "tasks".to_string(),
+            owner: "user@example.com".to_string(),
+            preview_ttl_hours: None,
+            idempotency_key: "idem-1".to_string(),
+            org_slug: None,
+        }
+    }
+
+    #[test]
+    fn validate_submit_checks_org_slug() {
+        let c = cfg();
+        // Absent org_slug is valid.
+        assert!(validate_submit(&c, &submit_req()).is_ok());
+        // A well-formed slug is valid.
+        let mut ok = submit_req();
+        ok.org_slug = Some("acme".to_string());
+        assert!(validate_submit(&c, &ok).is_ok());
+        // A malformed slug is rejected.
+        let mut bad = submit_req();
+        bad.org_slug = Some("Acme Inc".to_string());
+        assert!(validate_submit(&c, &bad).is_err());
+        // An empty slug is rejected: Some("") must not pass as a present value.
+        let mut empty = submit_req();
+        empty.org_slug = Some(String::new());
+        assert!(validate_submit(&c, &empty).is_err());
+    }
+
     #[test]
     fn valid_app_name_accepts_and_rejects() {
         assert!(valid_app_name("recipe-finder"));
@@ -366,11 +418,17 @@ mod tests {
 
     #[test]
     fn request_hash_is_stable_and_sensitive() {
-        let a = normalized_request_hash("app", "spec", "tasks", 24);
-        let b = normalized_request_hash("app", "spec", "tasks", 24);
+        let a = normalized_request_hash("app", None, "spec", "tasks", 24);
+        let b = normalized_request_hash("app", None, "spec", "tasks", 24);
         assert_eq!(a, b);
-        assert_ne!(a, normalized_request_hash("app", "spec-2", "tasks", 24));
-        assert_ne!(a, normalized_request_hash("app", "spec", "tasks", 48));
+        assert_ne!(a, normalized_request_hash("app", None, "spec-2", "tasks", 24));
+        assert_ne!(a, normalized_request_hash("app", None, "spec", "tasks", 48));
+        // The org slug is part of the request identity.
+        assert_ne!(a, normalized_request_hash("app", Some("acme"), "spec", "tasks", 24));
+        assert_ne!(
+            normalized_request_hash("app", Some("acme"), "spec", "tasks", 24),
+            normalized_request_hash("app", Some("beta"), "spec", "tasks", 24),
+        );
     }
 
     #[test]
@@ -393,8 +451,8 @@ mod tests {
         let t2 = clamp_ttl(&c, Some(500));
         assert_eq!(t1, t2);
         assert_eq!(
-            normalized_request_hash("app", "spec", "tasks", t1),
-            normalized_request_hash("app", "spec", "tasks", t2),
+            normalized_request_hash("app", None, "spec", "tasks", t1),
+            normalized_request_hash("app", None, "spec", "tasks", t2),
         );
     }
 

--- a/src/service/models.rs
+++ b/src/service/models.rs
@@ -110,6 +110,7 @@ impl JobStatus {
 pub enum ErrorCode {
     ValidationError,
     IdempotencyConflict,
+    AppNameConflict,
     QueueFull,
     BuildTimeout,
     BuildCrashed,
@@ -122,9 +123,10 @@ pub enum ErrorCode {
 impl ErrorCode {
     /// Every typed error code, in taxonomy order. Lets golden tests iterate
     /// the full error taxonomy exhaustively.
-    pub const ALL: [ErrorCode; 9] = [
+    pub const ALL: [ErrorCode; 10] = [
         ErrorCode::ValidationError,
         ErrorCode::IdempotencyConflict,
+        ErrorCode::AppNameConflict,
         ErrorCode::QueueFull,
         ErrorCode::BuildTimeout,
         ErrorCode::BuildCrashed,
@@ -138,6 +140,7 @@ impl ErrorCode {
         match self {
             ErrorCode::ValidationError => "validation_error",
             ErrorCode::IdempotencyConflict => "idempotency_conflict",
+            ErrorCode::AppNameConflict => "app_name_conflict",
             ErrorCode::QueueFull => "queue_full",
             ErrorCode::BuildTimeout => "build_timeout",
             ErrorCode::BuildCrashed => "build_crashed",
@@ -152,6 +155,7 @@ impl ErrorCode {
         match self {
             ErrorCode::ValidationError => 400,
             ErrorCode::IdempotencyConflict => 409,
+            ErrorCode::AppNameConflict => 409,
             ErrorCode::QueueFull => 429,
             _ => 500,
         }
@@ -422,9 +426,10 @@ mod tests {
     #[test]
     fn error_code_all_has_golden_strings_and_statuses() {
         use std::collections::HashSet;
-        let golden: [(ErrorCode, &str, u16); 9] = [
+        let golden: [(ErrorCode, &str, u16); 10] = [
             (ErrorCode::ValidationError, "validation_error", 400),
             (ErrorCode::IdempotencyConflict, "idempotency_conflict", 409),
+            (ErrorCode::AppNameConflict, "app_name_conflict", 409),
             (ErrorCode::QueueFull, "queue_full", 429),
             (ErrorCode::BuildTimeout, "build_timeout", 500),
             (ErrorCode::BuildCrashed, "build_crashed", 500),
@@ -437,9 +442,9 @@ mod tests {
             assert_eq!(code.as_str(), want_str);
             assert_eq!(code.http_status(), want_status);
         }
-        assert_eq!(ErrorCode::ALL.len(), 9);
+        assert_eq!(ErrorCode::ALL.len(), 10);
         let distinct: HashSet<&str> = ErrorCode::ALL.iter().map(|c| c.as_str()).collect();
-        assert_eq!(distinct.len(), 9, "every error code string is distinct");
+        assert_eq!(distinct.len(), 10, "every error code string is distinct");
     }
 
     #[test]

--- a/src/service/proxy.rs
+++ b/src/service/proxy.rs
@@ -187,6 +187,42 @@ fn oauth_headers(access_token: &str) -> Vec<(&'static str, String)> {
     ]
 }
 
+/// Append the comma-separated `anthropic-beta` tokens in `raw` to `into`,
+/// trimmed and de-duplicated.
+fn push_beta_tokens(raw: &str, into: &mut Vec<String>) {
+    for tok in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        if !into.iter().any(|p| p == tok) {
+            into.push(tok.to_string());
+        }
+    }
+}
+
+/// Merge the client's inbound `anthropic-beta` opt-ins with the beta tokens the
+/// upstream auth headers carry, into one de-duplicated header value. Returns
+/// `None` when neither side requests a beta.
+///
+/// The proxy rebuilds the upstream request from scratch, so without this merge
+/// the client's `anthropic-beta` is dropped — and a beta body field it depends
+/// on (e.g. `context_management`) is then rejected upstream with a 400
+/// "Extra inputs are not permitted".
+fn merge_anthropic_beta(
+    inbound: &HeaderMap,
+    auth_headers: &[(&'static str, String)],
+) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for v in inbound.get_all("anthropic-beta").iter() {
+        if let Ok(s) = v.to_str() {
+            push_beta_tokens(s, &mut parts);
+        }
+    }
+    for (name, value) in auth_headers {
+        if name.eq_ignore_ascii_case("anthropic-beta") {
+            push_beta_tokens(value, &mut parts);
+        }
+    }
+    (!parts.is_empty()).then(|| parts.join(","))
+}
+
 /// Decide whether an OAuth token must be refreshed: `true` when it is expired
 /// or within `skew` of expiry. A token with no expiry never needs refresh.
 fn needs_refresh(expires_at: Option<SystemTime>, now: SystemTime, skew: Duration) -> bool {
@@ -526,6 +562,10 @@ async fn messages_handler(
         return denied(&state, Some(&tok.job_id), ProxyDenial::TooManyConcurrent);
     }
 
+    // The client's `anthropic-beta` opt-ins must survive the request rebuild,
+    // merged with whatever the upstream credential requires — see
+    // `merge_anthropic_beta`.
+    let merged_beta = merge_anthropic_beta(&headers, &auth_headers);
     let mut request = state
         .proxy
         .http
@@ -533,7 +573,12 @@ async fn messages_handler(
         .header("anthropic-version", "2023-06-01")
         .header(header::CONTENT_TYPE, "application/json");
     for (name, value) in &auth_headers {
-        request = request.header(*name, value.as_str());
+        if !name.eq_ignore_ascii_case("anthropic-beta") {
+            request = request.header(*name, value.as_str());
+        }
+    }
+    if let Some(beta) = &merged_beta {
+        request = request.header("anthropic-beta", beta.as_str());
     }
     let upstream = request.body(body_bytes.to_vec()).send().await;
     tok.release();
@@ -602,6 +647,29 @@ mod tests {
                 ("anthropic-beta", "oauth-2025-04-20".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn merge_anthropic_beta_combines_client_and_oauth_deduped() {
+        let mut inbound = HeaderMap::new();
+        inbound.insert(
+            "anthropic-beta",
+            "context-management-2025-06-27, oauth-2025-04-20"
+                .parse()
+                .unwrap(),
+        );
+        let merged = merge_anthropic_beta(&inbound, &oauth_headers("tok")).unwrap();
+        assert!(merged.contains("context-management-2025-06-27"));
+        assert_eq!(
+            merged.matches("oauth-2025-04-20").count(),
+            1,
+            "the OAuth beta the client also sent must not be duplicated"
+        );
+    }
+
+    #[test]
+    fn merge_anthropic_beta_none_when_neither_side_sets_it() {
+        assert!(merge_anthropic_beta(&HeaderMap::new(), &api_key_headers("k")).is_none());
     }
 
     #[test]

--- a/src/service/worker.rs
+++ b/src/service/worker.rs
@@ -348,8 +348,13 @@ pub async fn drive_job(state: &Arc<AppState>, mut job: Job) {
     .await;
     let _ = db::insert_event(&state.pool, &job.id, "ready", Some(100), None).await;
 
-    // 15. Release the proxy token and storage grant.
-    cleanup(state, &token, &grant, &job.id).await;
+    // 15. Release the proxy token and storage grant. The build container is
+    //     `--rm` (already gone); the preview container and its Caddy route
+    //     MUST survive — they are the live deliverable — so `teardown` is
+    //     deliberately NOT called on the success path (unlike `cleanup`,
+    //     which tears the preview down and is only correct for failures).
+    state.proxy.revoke(&token);
+    let _ = state.storage.revoke_grant(&grant).await;
 }
 
 async fn cleanup(state: &Arc<AppState>, token: &str, grant: &StorageGrant, job_id: &str) {


### PR DESCRIPTION
## Summary

Deploying `foundry serve` (the `local_docker` backend, OAuth/subscription mode) on a VPS surfaced **eight defects** between job submission and a live preview. With these fixes a smoke build runs the full QRPBA pipeline on the Claude **subscription** and reaches `ready` with a surviving, health-checked preview container.

## Defects fixed

| # | Defect | Fix |
|---|--------|-----|
| 1 | Storage not host-shared → builder couldn't mount the work dir | compose: host-shared bind mount at an identical path |
| 2 | Per-build token sent as `x-api-key`; proxy reads `Authorization: Bearer` → 401 | inject `ANTHROPIC_AUTH_TOKEN` |
| 3 | `anthropic-beta` header dropped → `context_management` 400 | `merge_anthropic_beta` in the proxy |
| 4 | `preview_image_ref` not lowercased (uppercase ULID) → `docker build -t` rejects | lowercase the image ref |
| 5 | Preview unreachable — `--internal` network vs published port | route by container name on the shared network |
| 6 | Success path tore down the live preview | success path skips `teardown` |
| + | `azure_aca.rs` has the identical token-header defect | pinned with `TODO(auth-401)` — Azure is behind a feature flag, not fixed here |

Two proxy abuse-damper limits (`PROXY_MAX_OUTPUT_TOKENS`, `PROXY_MAX_CONCURRENT`) were also too low for a real Claude Code build — those are deployment config (service `.env`), not code, so they are not in this diff.

## Verification

- Smoke build `fj_01KRVF4X…` → `status: ready`, `cost_usd $1.62`, `audit: pass`, `tasks 2/2`, `0 WIP`; preview container `Up` and `GET / → HTTP 200`.
- `cargo test --release service::` — 67 unit tests pass, 0 failed (proxy/localdocker/caddy tests updated alongside the code).
- `scripts/check-claude-oauth.sh` **PASS** before and after every deploy — the host Claude subscription was never disturbed.

See the commit's **Auditor Summary** for the full claims/gaps checklist.

## Not in scope

External `*.knowmler.com` routing (wildcard DNS + a homelab-Caddy block) — the preview is verified reachable on the VPS-internal network only. Tracked in `docs/SPEC_knowmler-build-integration.md` (O1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)