### PR TITLE
feat: repo-aware headless Foundry for GitHub agents (Phase 36)

### DIFF
--- a/.github/workflows/foundry-agent.yml
+++ b/.github/workflows/foundry-agent.yml
@@ -16,11 +16,15 @@ on:
     types: [labeled]
 
 # Trust boundary:
-# - issue runs require a maintainer-applied 'foundry-agent' label (adding a label
-#   needs triage/write access), so untrusted users cannot trigger a credentialed run;
-# - we never trigger on pull_request, so forked-PR code never runs with secrets;
-# - --ignore-project-config skips checked-out .foundry.json settings while this
-#   workflow checks out only the trusted default branch, never forked PR code.
+# - never triggers on pull_request, so forked-PR code never runs with secrets;
+# - always checks out the trusted default branch (never a PR head), so the repo's
+#   .foundry.json IS trusted and is honored -- that is how per-stage routing
+#   reaches CI. We deliberately do NOT pass --ignore-project-config here; add it
+#   only if a future variant ever runs untrusted (PR-branch) code;
+# - issue runs require BOTH a maintainer-applied 'foundry-agent' label AND a
+#   trusted issue author (OWNER/MEMBER/COLLABORATOR). Residual risk: a labeled
+#   issue body becomes the agent task, so prompt-injection of a write-credentialed
+#   agent remains possible -- inherent to any issue-driven coding agent.
 permissions:
   contents: write
   checks: write
@@ -35,7 +39,9 @@ jobs:
   build:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issues' && github.event.label.name == 'foundry-agent')
+      (github.event_name == 'issues' &&
+       github.event.label.name == 'foundry-agent' &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -81,7 +87,7 @@ jobs:
             BRANCH="foundry/dispatch-${{ github.run_id }}"
           else
             TASK="${ISSUE_TITLE}: ${ISSUE_BODY}"
-            BRANCH="foundry/issue-${ISSUE_NUMBER}"
+            BRANCH="foundry/issue-${ISSUE_NUMBER}-${GITHUB_RUN_ID}"
           fi
           git switch -c "$BRANCH"
           ONELINE="$(printf '%s' "$TASK" | tr '\n' ' ')"
@@ -111,12 +117,15 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           set -o pipefail
+          # Honors the (trusted, default-branch) repo .foundry.json for per-stage
+          # routing; the ci profile overlays bounded service behavior on top.
+          # Run status (PASS/WIP/FAIL) is derived from the SessionReport by the
+          # report script below and surfaced via the check-run -- not via the
+          # process exit code -- so the PR always opens for human review.
           foundry run \
             --no-tui \
             --output-format json-stream \
             --profile "${{ github.event.inputs.profile || 'ci' }}" \
-            --ignore-project-config \
-            --exit-on-wip \
             | tee foundry-stream.jsonl
 
       - name: Render report

--- a/.github/workflows/foundry-agent.yml
+++ b/.github/workflows/foundry-agent.yml
@@ -1,0 +1,186 @@
+name: Foundry Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Task for Foundry to implement (one mental-model change)."
+        required: true
+        type: string
+      profile:
+        description: "Config profile overlay (default: ci)."
+        required: false
+        default: "ci"
+        type: string
+  issues:
+    types: [labeled]
+
+# Trust boundary:
+# - issue runs require a maintainer-applied 'foundry-agent' label (adding a label
+#   needs triage/write access), so untrusted users cannot trigger a credentialed run;
+# - we never trigger on pull_request, so forked-PR code never runs with secrets;
+# - --ignore-project-config skips checked-out .foundry.json settings while this
+#   workflow checks out only the trusted default branch, never forked PR code.
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: foundry-agent-${{ github.repository }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.label.name == 'foundry-agent')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "foundry-agent[bot]"
+          git config user.email "foundry-agent@users.noreply.github.com"
+
+      - name: Install foundry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          gh release download --repo context-foundry/context-foundry --pattern 'foundry-linux.tar.gz' -D /tmp
+          tar xzf /tmp/foundry-linux.tar.gz -C /tmp
+          chmod +x /tmp/foundry
+          sudo mv /tmp/foundry /usr/local/bin/foundry
+          foundry --version
+
+      - name: Install Claude CLI
+        # foundry run spawns the `claude` CLI in a PTY; it must be on PATH and the
+        # job env must carry ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN (below).
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Prepare branch and task queue
+        id: prep
+        env:
+          GH_EVENT: ${{ github.event_name }}
+          DISPATCH_TASK: ${{ github.event.inputs.task }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          if [ "$GH_EVENT" = "workflow_dispatch" ]; then
+            TASK="$DISPATCH_TASK"
+            BRANCH="foundry/dispatch-${{ github.run_id }}"
+          else
+            TASK="${ISSUE_TITLE}: ${ISSUE_BODY}"
+            BRANCH="foundry/issue-${ISSUE_NUMBER}"
+          fi
+          git switch -c "$BRANCH"
+          ONELINE="$(printf '%s' "$TASK" | tr '\n' ' ')"
+          TASK_ID="F${GITHUB_RUN_ID}.1"
+
+          if [ ! -e SPEC.md ]; then
+            printf '# Spec\n' > SPEC.md
+          elif [ -s SPEC.md ] && [ -n "$(tail -c 1 SPEC.md || true)" ]; then
+            printf '\n' >> SPEC.md
+          fi
+          printf '\n## Foundry Agent %s\n\n%s\n' "$GITHUB_RUN_ID" "$TASK" >> SPEC.md
+
+          if [ ! -e TASKS.md ]; then
+            printf '# Task Queue\n' > TASKS.md
+          elif [ -s TASKS.md ] && [ -n "$(tail -c 1 TASKS.md || true)" ]; then
+            printf '\n' >> TASKS.md
+          fi
+          printf '\n## Foundry Agent %s\n\n' "$GITHUB_RUN_ID" >> TASKS.md
+          printf -- '- [ ] %s: %s\n' "$TASK_ID" "$ONELINE" >> TASKS.md
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Run foundry (headless, ci profile)
+        id: run
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set -o pipefail
+          foundry run \
+            --no-tui \
+            --output-format json-stream \
+            --profile "${{ github.event.inputs.profile || 'ci' }}" \
+            --ignore-project-config \
+            --exit-on-wip \
+            | tee foundry-stream.jsonl
+
+      - name: Render report
+        if: always()
+        run: |
+          python3 scripts/foundry-ci-report.py foundry-stream.jsonl > foundry-report.md \
+            || echo "Report generation failed." > foundry-report.md
+          cat foundry-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Push branch
+        run: git push -u origin "${{ steps.prep.outputs.branch }}"
+
+      - name: Create check run
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CONCLUSION="$(python3 scripts/foundry-ci-report.py --conclusion foundry-stream.jsonl || echo failure)"
+          TITLE="$(python3 scripts/foundry-ci-report.py --title foundry-stream.jsonl || echo 'Foundry build: incomplete')"
+          gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
+            -X POST \
+            -f name="Foundry Agent" \
+            -f head_sha="$(git rev-parse HEAD)" \
+            -f status="completed" \
+            -f conclusion="$CONCLUSION" \
+            -f "output[title]=$TITLE" \
+            -f "output[summary]=$(cat foundry-report.md)" \
+            --silent \
+            || echo "Check-run creation skipped."
+
+      - name: Open PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATUS="$(python3 scripts/foundry-ci-report.py --status foundry-stream.jsonl || echo WIP)"
+          PR_URL="$(gh pr create \
+            --base "${{ github.event.repository.default_branch }}" \
+            --head "${{ steps.prep.outputs.branch }}" \
+            --title "${STATUS}: foundry-agent ${{ steps.prep.outputs.branch }}" \
+            --body-file foundry-report.md 2>/tmp/foundry-pr-create.err || true)"
+          if [ -z "$PR_URL" ]; then
+            cat /tmp/foundry-pr-create.err
+            PR_URL="$(gh pr view "${{ steps.prep.outputs.branch }}" --json url -q .url 2>/dev/null || true)"
+          fi
+          if [ -n "$PR_URL" ]; then
+            echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "PR creation skipped (no commits or PR already exists)."
+          fi
+
+      - name: Comment report on PR
+        if: steps.pr.outputs.url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "${{ steps.pr.outputs.url }}" --body-file foundry-report.md
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: buildloop-${{ github.run_id }}
+          path: |
+            .buildloop/
+            foundry-stream.jsonl
+            foundry-report.md
+          if-no-files-found: warn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "foundry"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foundry"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 description = "Autonomous build loop — the engine of Context Foundry"
 license = "MIT"

--- a/docs/PLAN_github-cloud-agent.md
+++ b/docs/PLAN_github-cloud-agent.md
@@ -1,0 +1,125 @@
+# Plan: Repo-aware headless Foundry for GitHub agents (v3, post-convergence)
+
+Date: 2026-05-22
+Version: v3
+Status: in-progress
+
+## Audit changelog (vs v2)
+
+v2 described "Architecture B" -- keep the VPS running `foundry serve` as the engine,
+add `/v1/skills` + `/v1/plugins` endpoints, build an `npm` MCP wrapper with 8 tools,
+wire a GitHub App, and deploy via `gh`. Three rounds of audit in conversation
+(2026-05-22) rejected that ordering. The reasons:
+
+- **The execution primitive already exists.** `foundry run --no-tui --output-format
+  json-stream` (src/main.rs:61) -> `app::run_headless` (src/app/commands.rs:467)
+  already runs against the current checkout, loads merged Config (global -> project
+  `.foundry.json`, src/config.rs:980), respects per-stage routing, writes
+  `.buildloop`, makes per-task `feat:`/`WIP:` commits (src/git.rs), and emits a
+  versioned `SessionReport` with commits/cost/findings/typed_error
+  (src/app/commands.rs:797). A new `run-repo` command would duplicate
+  `Commands::Run`.
+- **v2 built surfaces before the primitive.** Skill endpoints, an MCP wrapper, and a
+  GitHub App are integration scaffolding. They are not what makes Foundry a GitHub
+  coding agent; a repo-aware headless run that opens a PR is.
+- **The VPS is not required.** In a GitHub runner `actions/checkout` already places
+  the repo on disk, and the runner token already pushes and opens PRs. So
+  "repo-aware" needs zero clone logic and no remote build service in v1.
+- **v2 would have lost per-stage model control.** The service build profile
+  hard-pins providers and clears `stage_overrides` (src/service/localdocker.rs:44).
+  The fix is a profile overlay, not a remote service.
+
+This v3 supersedes v2. The task breakdown lives in `TASKS.md` Phase 36.
+
+## Context
+
+Run Context Foundry's QRPBA pipeline (Query / Research / Plan / Build / Audit)
+against an existing GitHub repository, from a GitHub Actions runner, landing the
+work as per-task commits on a branch with a PR. The same headless primitive also
+serves VS Code and (later, optionally) the Copilot cloud agent. The TUI stays a
+local-only frontend.
+
+**Architecture: repo-aware headless Foundry.** The runner is both the frontend
+input (issue/label/dispatch) and the sandbox (the checked-out repo). Foundry runs
+headless inside it. There is no always-on service, no MCP bridge, and no GitHub App
+in v1. GitHub is the product surface (issues to request, PRs/checks/comments to
+review); Foundry is the engine.
+
+This follows the open-agents lesson ("the agent is not the sandbox") with the
+pragmatic simplification that for fire-and-forget "implement this task, open a PR"
+work the GitHub runner IS the sandbox, so we do not need a separate hibernating VM.
+
+**Target repo:** `snedea/context-foundry` (private; separate from
+`origin = context-foundry/context-foundry`).
+
+## Current state (verified against source, 2026-05-22)
+
+- `Commands::Run` exposes `--no-tui` and `--output-format json|json-stream`
+  (src/main.rs:61-68), dispatching to `app::run_headless` (src/app/commands.rs:467).
+- Headless run loads `Config` via the global->project merge (src/config.rs:980) and
+  respects per-stage routing (`active_routing_for_stage`).
+- Terminal `SessionReport` carries per-task status, commit SHAs, feat/WIP counts,
+  cost, and `typed_error` (src/app/commands.rs:797). A JSONL `StreamEmitter` drives
+  `json-stream`.
+- `run_mode = "service"` is behavior-only (src/app/service_mode.rs): empty-queue
+  termination, no Discovery, no bootstrap Scout, WIP-terminal, no update check. It
+  does NOT touch model/provider/stage routing.
+- `render_service_profile()` (src/service/localdocker.rs:44) is a SEPARATE thing --
+  it writes a whole `.foundry.json` that pins providers to Claude and clears
+  `stage_overrides`. The CI profile must NOT be derived from it.
+- `agent.rs` spawns the `claude` CLI in a PTY and relies on ambient auth; it has no
+  `ANTHROPIC_API_KEY` handling of its own and only knows `ANTHROPIC_BASE_URL`
+  (src/config.rs:456). The "two worlds" split: interactive=Keychain, serve=proxy.
+- `ReviewPr` already has `--ignore-project-config` for CI trust (src/main.rs:104-107);
+  `Commands::Run` does not yet.
+- The greenfield `foundry serve` build service (Phase 35, v4.0.0) seeds work dirs
+  with SPEC.md/TASKS.md only (src/service/localdocker.rs:649) and builds preview
+  containers. Repo-aware mode is ADDITIVE and must not break it.
+
+## Implementation steps (-> TASKS.md Phase 36)
+
+- [ ] T36.1 -- headless provider auth in a Keychain-less runner (env passthrough +
+      manual smoke). The gate; prove it before the rest.
+- [ ] T36.2 -- `--profile <name>` Config overlay + a built-in `ci` profile
+      (`run_mode=service` + provider allowlist + budget caps; preserves routing).
+- [ ] T36.3 -- exit-code policy for headless runs (0 only when all feat/pass).
+- [ ] T36.4 -- `run --ignore-project-config` trust flag (mirror ReviewPr).
+- [ ] T36.5 -- label/dispatch-gated `.github/workflows/foundry-agent.yml` that
+      checks out, branches first, runs headless, pushes, opens a PR, uploads
+      `.buildloop`.
+- [ ] T36.6 -- PR/check reporting from the `SessionReport`.
+- [ ] T36.7 -- (deferred, optional) MCP launcher for VS Code / Copilot.
+- [ ] T36.8 -- (deferred) GitHub App packaging.
+
+## Architecture decisions
+
+- **No new command.** Extend `Commands::Run`, do not add `run-repo`.
+- **No second config universe.** A named profile is a thin overlay onto the existing
+  `Config` (global -> project -> profile). `.github/foundry.yml`, if used later, maps
+  into `Config`, it does not replace it.
+- **`run_mode` and model routing are independent.** The `ci` profile sets bounded
+  behavior and a provider allowlist; it inherits stage routing from the repo.
+- **Runner is the sandbox.** No clone logic, no tarball artifact, no remote service
+  in v1; GitHub provides the checkout, token, and PR.
+- **Trust boundary.** In CI, refuse to honor an untrusted PR branch's `.foundry.json`
+  (`--ignore-project-config`); only trusted triggers (dispatch / maintainer label).
+- **Defer the heavy surfaces.** MCP launcher and GitHub App come only after the
+  Action path is proven.
+
+## Risks and open questions
+
+- **Auth is the real gate (T36.1).** No Keychain in a runner. The `claude` CLI must
+  authenticate from `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` in the runner
+  env. Unproven until the manual smoke runs.
+- **CI provider set is small.** LM Studio (desktop GUI) and Ollama (model pulls +
+  disk + minutes) are non-starters in a stock runner. CI realistically = Claude
+  and/or Codex via API-key secrets. The `ci` profile declares the allowed set and
+  fails fast otherwise.
+- **Cost/runtime.** A QRPBA run is 25-60 min and $8-20 unattended. The `ci` profile
+  sets budget/runtime caps; the workflow sets `timeout-minutes`.
+- **Durability is deferred.** A dead runner mid-run loses progress. v1 just uploads
+  `.buildloop` as an artifact for a human re-run; resumable branch state is a later
+  epic (GitHub Actions cannot cheaply match open-agents' VM snapshotting).
+- **Do not break the greenfield service.** Phase 35's `foundry serve` shares
+  `app::run_headless`; the profile work fixes its over-constraint rather than forking
+  a third execution path.

--- a/docs/PLAN_github-cloud-agent.md
+++ b/docs/PLAN_github-cloud-agent.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-22
 Version: v3
-Status: in-progress
+Status: implemented locally; release + clean-runner smoke pending
 
 ## Audit changelog (vs v2)
 
@@ -70,8 +70,8 @@ work the GitHub runner IS the sandbox, so we do not need a separate hibernating 
 - `agent.rs` spawns the `claude` CLI in a PTY and relies on ambient auth; it has no
   `ANTHROPIC_API_KEY` handling of its own and only knows `ANTHROPIC_BASE_URL`
   (src/config.rs:456). The "two worlds" split: interactive=Keychain, serve=proxy.
-- `ReviewPr` already has `--ignore-project-config` for CI trust (src/main.rs:104-107);
-  `Commands::Run` does not yet.
+- `ReviewPr` already had `--ignore-project-config` for CI trust; `Commands::Run`
+  now has the same flag for future untrusted-run variants.
 - The greenfield `foundry serve` build service (Phase 35, v4.0.0) seeds work dirs
   with SPEC.md/TASKS.md only (src/service/localdocker.rs:649) and builds preview
   containers. Repo-aware mode is ADDITIVE and must not break it.
@@ -80,14 +80,14 @@ work the GitHub runner IS the sandbox, so we do not need a separate hibernating 
 
 - [ ] T36.1 -- headless provider auth in a Keychain-less runner (env passthrough +
       manual smoke). The gate; prove it before the rest.
-- [ ] T36.2 -- `--profile <name>` Config overlay + a built-in `ci` profile
+- [x] T36.2 -- `--profile <name>` Config overlay + a built-in `ci` profile
       (`run_mode=service` + provider allowlist + budget caps; preserves routing).
-- [ ] T36.3 -- exit-code policy for headless runs (0 only when all feat/pass).
-- [ ] T36.4 -- `run --ignore-project-config` trust flag (mirror ReviewPr).
-- [ ] T36.5 -- label/dispatch-gated `.github/workflows/foundry-agent.yml` that
+- [x] T36.3 -- exit-code policy for headless runs (0 only when all feat/pass).
+- [x] T36.4 -- `run --ignore-project-config` trust flag (mirror ReviewPr).
+- [x] T36.5 -- label/dispatch-gated `.github/workflows/foundry-agent.yml` that
       checks out, branches first, runs headless, pushes, opens a PR, uploads
       `.buildloop`.
-- [ ] T36.6 -- PR/check reporting from the `SessionReport`.
+- [x] T36.6 -- PR/check reporting from the `SessionReport`.
 - [ ] T36.7 -- (deferred, optional) MCP launcher for VS Code / Copilot.
 - [ ] T36.8 -- (deferred) GitHub App packaging.
 
@@ -101,8 +101,11 @@ work the GitHub runner IS the sandbox, so we do not need a separate hibernating 
   behavior and a provider allowlist; it inherits stage routing from the repo.
 - **Runner is the sandbox.** No clone logic, no tarball artifact, no remote service
   in v1; GitHub provides the checkout, token, and PR.
-- **Trust boundary.** In CI, refuse to honor an untrusted PR branch's `.foundry.json`
-  (`--ignore-project-config`); only trusted triggers (dispatch / maintainer label).
+- **Trust boundary.** The v1 Action never checks out a PR head. It checks out the
+  trusted default branch, honors that branch's `.foundry.json` so per-stage routing
+  works in CI, and gates issue-triggered runs by both maintainer label and trusted
+  issue author. Future variants that run untrusted PR code must use
+  `--ignore-project-config`.
 - **Defer the heavy surfaces.** MCP launcher and GitHub App come only after the
   Action path is proven.
 

--- a/scripts/foundry-ci-report.py
+++ b/scripts/foundry-ci-report.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Render a Foundry headless json-stream into a Markdown PR/check report.
+
+Usage:
+    foundry-ci-report.py <stream.jsonl>
+
+Reads the JSONL event stream produced by
+`foundry run --no-tui --output-format json-stream`, extracts the terminal
+SessionReport (the final object carrying both `session` and `tasks`), and writes
+a Markdown summary to stdout. Used for the PR body and the GitHub step summary.
+Degrades gracefully when the report is missing or the stream is truncated.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_STATUS_LABELS = {"pass": "PASS", "feat": "PASS", "wip": "WIP", "fail": "FAIL"}
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def find_report(lines: list[str]) -> dict[str, Any] | None:
+    """Return the last JSONL line that looks like a terminal SessionReport."""
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "session" in obj and "tasks" in obj:
+            return obj
+    return None
+
+
+def status_label(status: str) -> str:
+    return _STATUS_LABELS.get(status.lower(), status or "?")
+
+
+def outcome(report: dict[str, Any]) -> tuple[str, str]:
+    """Return (display_status, GitHub check conclusion)."""
+    session: dict[str, Any] = report.get("session", {})
+    feat = _int(session.get("feat_commits"))
+    wip = _int(session.get("wip_commits"))
+    if report.get("typed_error"):
+        return ("FAIL", "failure")
+    if wip == 0 and feat > 0:
+        return ("PASS", "success")
+    return ("WIP", "neutral")
+
+
+def render(report: dict[str, Any]) -> str:
+    session: dict[str, Any] = report.get("session", {})
+    tasks: list[dict[str, Any]] = report.get("tasks", [])
+    cfg: dict[str, Any] = report.get("config", {})
+    feat = _int(session.get("feat_commits"))
+    wip = _int(session.get("wip_commits"))
+    cost = _float(report.get("cost_usd"))
+    duration = _float(session.get("total_duration_secs"))
+    overall, _conclusion = outcome(report)
+
+    out: list[str] = [
+        f"## Foundry build: {overall}",
+        "",
+        f"- Tasks: {len(tasks)} (feat {feat} / wip {wip})",
+        f"- Cost: ${cost:.2f} | Duration: {duration:.0f}s",
+        f"- Run mode: {cfg.get('run_mode', '?')} | "
+        f"builder {cfg.get('builder_provider', '?')}:{cfg.get('builder_model', '?')}",
+    ]
+    typed_error = report.get("typed_error")
+    if typed_error:
+        out.append(f"- Typed error: `{json.dumps(typed_error)}`")
+    out.append("")
+
+    if tasks:
+        out.append("| Task | Status | H/M/L | Commit | Secs |")
+        out.append("|------|--------|-------|--------|------|")
+        for task in tasks:
+            findings: dict[str, Any] = task.get("findings", {})
+            sha = (task.get("commit_sha") or "")[:8] or "-"
+            out.append(
+                f"| {task.get('id', '?')} "
+                f"| {status_label(task.get('status', ''))} "
+                f"| {findings.get('high', 0)}/{findings.get('medium', 0)}/{findings.get('low', 0)} "
+                f"| `{sha}` "
+                f"| {_float(task.get('duration_secs')):.0f} |"
+            )
+        out.append("")
+
+    out.append("_Automated by `foundry run` (ci profile)._")
+    return "\n".join(out)
+
+
+def load_report(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return None, "Stream file not found."
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    report = find_report(lines)
+    if report is None:
+        return None, "No terminal SessionReport found in the event stream."
+    return report, None
+
+
+def main() -> int:
+    if len(sys.argv) not in (2, 3):
+        print(
+            "usage: foundry-ci-report.py [--status|--conclusion|--title] <stream.jsonl>",
+            file=sys.stderr,
+        )
+        return 2
+
+    mode = "render"
+    path_arg = sys.argv[1]
+    if len(sys.argv) == 3:
+        mode = sys.argv[1]
+        path_arg = sys.argv[2]
+        if mode not in {"--status", "--conclusion", "--title"}:
+            print(f"unknown option: {mode}", file=sys.stderr)
+            return 2
+
+    path = Path(path_arg)
+    report, missing_reason = load_report(path)
+    if report is None:
+        if mode == "--status":
+            print("FAIL")
+            return 0
+        if mode == "--conclusion":
+            print("failure")
+            return 0
+        if mode == "--title":
+            print("Foundry build: incomplete")
+            return 0
+        print(
+            "## Foundry build: incomplete\n\n"
+            f"{missing_reason}"
+        )
+        return 0
+    status, conclusion = outcome(report)
+    if mode == "--status":
+        print(status)
+        return 0
+    if mode == "--conclusion":
+        print(conclusion)
+        return 0
+    if mode == "--title":
+        print(f"Foundry build: {status}")
+        return 0
+    print(render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/app.rs
+++ b/src/app.rs
@@ -3955,11 +3955,9 @@ fn handle_event(state: &mut AppState, event: AppEvent, config: &Config) {
                             state.agent_pane_split = pct;
                         }
                     }
-                    MouseEventKind::Up(MouseButton::Left) => {
-                        if state.dragging_split {
-                            state.dragging_split = false;
-                            Config::save_agent_pane_split_global(state.agent_pane_split);
-                        }
+                    MouseEventKind::Up(MouseButton::Left) if state.dragging_split => {
+                        state.dragging_split = false;
+                        Config::save_agent_pane_split_global(state.agent_pane_split);
                     }
                     _ => {}
                 }
@@ -6277,25 +6275,25 @@ fn handle_startup_mouse_at_for_running(
     let preview_area = middle_cols[1];
 
     match mouse.kind {
-        MouseEventKind::Down(MouseButton::Right) => {
+        MouseEventKind::Down(MouseButton::Right)
+            if tui::rect_contains(explorer_area, mouse.column, mouse.row) =>
+        {
             // Right-click opens an AI-summary context menu on a file entry.
-            if tui::rect_contains(explorer_area, mouse.column, mouse.row) {
-                if let Some(ref explorer) = state.running_explorer {
-                    let inner_top = explorer_area.y + 1;
-                    let inner_bottom = explorer_area.y + explorer_area.height.saturating_sub(1);
-                    if mouse.row >= inner_top && mouse.row < inner_bottom {
-                        let relative_row = (mouse.row - inner_top) as usize;
-                        let vis = explorer.visible_indices();
-                        let vis_index = explorer.explorer_scroll + relative_row;
-                        if let Some(&tree_idx) = vis.get(vis_index) {
-                            if let Some(entry) = explorer.file_tree.get(tree_idx) {
-                                if !entry.is_dir {
-                                    state.explorer_context_menu = Some(ExplorerContextMenu {
-                                        anchor_col: mouse.column,
-                                        anchor_row: mouse.row,
-                                        file_path: entry.path.clone(),
-                                    });
-                                }
+            if let Some(ref explorer) = state.running_explorer {
+                let inner_top = explorer_area.y + 1;
+                let inner_bottom = explorer_area.y + explorer_area.height.saturating_sub(1);
+                if mouse.row >= inner_top && mouse.row < inner_bottom {
+                    let relative_row = (mouse.row - inner_top) as usize;
+                    let vis = explorer.visible_indices();
+                    let vis_index = explorer.explorer_scroll + relative_row;
+                    if let Some(&tree_idx) = vis.get(vis_index) {
+                        if let Some(entry) = explorer.file_tree.get(tree_idx) {
+                            if !entry.is_dir {
+                                state.explorer_context_menu = Some(ExplorerContextMenu {
+                                    anchor_col: mouse.column,
+                                    anchor_row: mouse.row,
+                                    file_path: entry.path.clone(),
+                                });
                             }
                         }
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5446,8 +5446,21 @@ pub async fn run_plan_mode(project_dir: &Path, max_iterations: u64) -> Result<()
 
 // ─── Headless Mode ───────────────────────────────────────────
 
-pub async fn run_headless(project_dir: &Path, output_format: Option<String>) -> Result<()> {
-    commands::run_headless(project_dir, output_format).await
+pub async fn run_headless(
+    project_dir: &Path,
+    output_format: Option<String>,
+    profile: Option<String>,
+    ignore_project_config: bool,
+    exit_on_wip: bool,
+) -> Result<i32> {
+    commands::run_headless(
+        project_dir,
+        output_format,
+        profile,
+        ignore_project_config,
+        exit_on_wip,
+    )
+    .await
 }
 
 // ─── Status & Tasks Commands ─────────────────────────────────

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -436,6 +436,8 @@ fn required_providers(
         ProviderCommandMode::Run => {
             let mut v = vec![
                 ("scout", Config::parse_provider(&config.scout_provider)),
+                ("query", Config::parse_provider(&config.query_provider)),
+                ("research", Config::parse_provider(&config.research_provider)),
                 ("planner", Config::parse_provider(&config.planner_provider)),
                 (
                     "discovery",

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
@@ -208,6 +208,70 @@ pub(crate) fn ensure_required_providers_available(
     anyhow::bail!(
         "required provider CLI not found: {}. Install the missing CLI(s) or change the corresponding *.provider setting in .foundry.json",
         details
+    );
+}
+
+fn provider_allowlist_slug(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "claude" => Some("claude"),
+        "codex" => Some("codex"),
+        "opencode" => Some("opencode"),
+        "ghcopilot" | "gh-copilot" | "copilot" => Some("ghcopilot"),
+        _ => None,
+    }
+}
+
+fn ensure_required_providers_allowed(config: &Config, mode: ProviderCommandMode) -> Result<()> {
+    if config.provider_allowlist.is_empty() {
+        return Ok(());
+    }
+
+    let mut allowed = BTreeSet::new();
+    let mut invalid = Vec::new();
+    for entry in &config.provider_allowlist {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match provider_allowlist_slug(trimmed) {
+            Some(slug) => {
+                allowed.insert(slug);
+            }
+            None => invalid.push(trimmed.to_string()),
+        }
+    }
+
+    if !invalid.is_empty() {
+        anyhow::bail!(
+            "unknown provider(s) in provider_allowlist: {}",
+            invalid.join(", ")
+        );
+    }
+    if allowed.is_empty() {
+        anyhow::bail!("provider_allowlist must name at least one provider when configured");
+    }
+
+    let mut disallowed: BTreeMap<&'static str, Vec<&'static str>> = BTreeMap::new();
+    for (role, provider) in required_providers(config, mode) {
+        let slug = provider.slug();
+        if !allowed.contains(slug) {
+            disallowed.entry(slug).or_default().push(role);
+        }
+    }
+
+    if disallowed.is_empty() {
+        return Ok(());
+    }
+
+    let disallowed = disallowed
+        .into_iter()
+        .map(|(provider, roles)| format!("{provider} ({})", roles.join(", ")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    anyhow::bail!(
+        "provider not allowed by provider_allowlist: {}. Allowed providers: {}",
+        disallowed,
+        allowed.into_iter().collect::<Vec<_>>().join(", ")
     );
 }
 
@@ -464,9 +528,23 @@ fn required_providers(
     providers
 }
 
-pub(super) async fn run_headless(project_dir: &Path, output_format: Option<String>) -> Result<()> {
+fn headless_exit_code(exit_on_wip: bool, feat_commits: usize, wip_commits: usize) -> i32 {
+    if exit_on_wip && (wip_commits > 0 || feat_commits == 0) {
+        1
+    } else {
+        0
+    }
+}
+
+pub(super) async fn run_headless(
+    project_dir: &Path,
+    output_format: Option<String>,
+    profile: Option<String>,
+    ignore_project_config: bool,
+    exit_on_wip: bool,
+) -> Result<i32> {
     let contract_paths = ContractPaths::resolve(project_dir);
-    let mut config = Config::load(project_dir);
+    let mut config = Config::load_layered(project_dir, ignore_project_config, profile.as_deref())?;
     if config.run_mode == "review" {
         eprintln!(
             "[foundry] review mode is not supported in headless mode -- falling back to auto"
@@ -509,6 +587,7 @@ pub(super) async fn run_headless(project_dir: &Path, output_format: Option<Strin
         );
     }
 
+    ensure_required_providers_allowed(&run_context.config, ProviderCommandMode::Run)?;
     ensure_required_providers_available(&run_context.config, ProviderCommandMode::Run)?;
 
     // Sandbox detection (headless)
@@ -850,7 +929,11 @@ pub(super) async fn run_headless(project_dir: &Path, output_format: Option<Strin
         );
     }
 
-    Ok(())
+    // T36.3: opt-in CI exit policy. Default (exit_on_wip = false) preserves the
+    // build-service contract, where a WIP / audit-failed task still yields a
+    // successful headless run. With --exit-on-wip the GitHub Action gets a
+    // non-zero status when any task ended WIP / audit-failed or nothing passed.
+    Ok(headless_exit_code(exit_on_wip, feat_commits, wip_commits))
 }
 
 pub(super) fn show_status(project_dir: &Path) -> Result<()> {
@@ -1837,9 +1920,10 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::{
-        format_status_output, format_tasks_output, migrate_to_skills_in_dir,
-        missing_provider_commands, prune_stale_in_dir, ConfigSnapshot, OutputMode,
-        ProviderCommandMode, SessionReport, SessionStats, HEADLESS_REPORT_SCHEMA_VERSION,
+        ensure_required_providers_allowed, format_status_output, format_tasks_output,
+        headless_exit_code, migrate_to_skills_in_dir, missing_provider_commands,
+        prune_stale_in_dir, ConfigSnapshot, OutputMode, ProviderCommandMode, SessionReport,
+        SessionStats, HEADLESS_REPORT_SCHEMA_VERSION,
     };
     use crate::agent::ModelProvider;
     use crate::config::Config;
@@ -1878,7 +1962,10 @@ mod tests {
             typed_error: None,
         };
         let s = serde_json::to_string(&report).expect("serialize");
-        assert!(!s.contains('\n'), "json-stream report must be a single line");
+        assert!(
+            !s.contains('\n'),
+            "json-stream report must be a single line"
+        );
         let v: serde_json::Value = serde_json::from_str(&s).expect("parse");
         assert_eq!(v["schema_version"], 3);
         assert_eq!(v["cost_usd"], 1.25);
@@ -1900,6 +1987,63 @@ mod tests {
         assert!(OutputMode::Json.is_json());
         assert!(OutputMode::JsonStream.is_json());
         assert!(!OutputMode::Human.is_json());
+    }
+
+    #[test]
+    fn headless_exit_policy_preserves_default_service_contract() {
+        assert_eq!(headless_exit_code(false, 0, 0), 0);
+        assert_eq!(headless_exit_code(false, 0, 1), 0);
+        assert_eq!(headless_exit_code(false, 1, 1), 0);
+    }
+
+    #[test]
+    fn headless_exit_policy_flags_wip_and_empty_when_enabled() {
+        assert_eq!(headless_exit_code(true, 1, 0), 0);
+        assert_eq!(headless_exit_code(true, 1, 1), 1);
+        assert_eq!(headless_exit_code(true, 0, 0), 1);
+    }
+
+    #[test]
+    fn provider_allowlist_allows_empty_and_matching_required_providers() {
+        let unrestricted = Config {
+            builder_provider: "opencode".into(),
+            ..Config::default()
+        };
+        assert!(ensure_required_providers_allowed(&unrestricted, ProviderCommandMode::Run).is_ok());
+
+        let allowed = Config {
+            provider_allowlist: vec!["claude".into(), "codex".into()],
+            builder_provider: "codex".into(),
+            ..Config::default()
+        };
+        assert!(ensure_required_providers_allowed(&allowed, ProviderCommandMode::Run).is_ok());
+    }
+
+    #[test]
+    fn provider_allowlist_rejects_disallowed_required_provider() {
+        let config = Config {
+            provider_allowlist: vec!["claude".into(), "codex".into()],
+            builder_provider: "opencode".into(),
+            ..Config::default()
+        };
+        let err = ensure_required_providers_allowed(&config, ProviderCommandMode::Run)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("provider not allowed by provider_allowlist"));
+        assert!(err.contains("opencode (builder)"));
+        assert!(err.contains("Allowed providers: claude, codex"));
+    }
+
+    #[test]
+    fn provider_allowlist_rejects_unknown_entries() {
+        let config = Config {
+            provider_allowlist: vec!["mystery".into()],
+            ..Config::default()
+        };
+        let err = ensure_required_providers_allowed(&config, ProviderCommandMode::Run)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown provider(s) in provider_allowlist: mystery"));
     }
 
     fn write_plan(dir: &Path, contents: &str) -> Vec<task::Task> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,9 @@ pub struct Config {
     pub reviewer_provider: String,
     pub fixer_provider: String,
     pub discovery_provider: String,
+    /// Optional provider allowlist for headless runs. Empty means unrestricted.
+    #[serde(default)]
+    pub provider_allowlist: Vec<String>,
 
     pub pause_between_tasks_secs: u64,
     pub pause_between_agents_secs: u64,
@@ -638,6 +641,7 @@ impl Default for Config {
             reviewer_provider: "claude".into(),
             fixer_provider: "claude".into(),
             discovery_provider: "claude".into(),
+            provider_allowlist: Vec::new(),
 
             pause_between_tasks_secs: 10,
             pause_between_agents_secs: 3,
@@ -1020,6 +1024,75 @@ impl Config {
         config.normalize();
         config.apply_env_overrides();
         config
+    }
+
+    /// JSON overlay for a built-in named profile, or `None` for an unknown name.
+    ///
+    /// A profile is applied as the top layer over global+project config, so it
+    /// only sets the fields it names and inherits everything else -- notably
+    /// per-stage routing (`stage_overrides`, providers, models). The `ci`
+    /// profile is the unattended GitHub-runner profile: bounded `service`
+    /// behavior with the agent sandbox OFF so the spawned provider CLI inherits
+    /// the runner's auth env (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`).
+    /// It deliberately does NOT pin providers/models or clear `stage_overrides`
+    /// the way `render_service_profile()` does.
+    pub fn builtin_profile_json(name: &str) -> Option<serde_json::Value> {
+        match name {
+            "ci" => Some(serde_json::json!({
+                "run_mode": "service",
+                "sandbox": false,
+                "cost_limit": 20.0,
+                "provider_allowlist": ["claude", "codex"],
+            })),
+            _ => None,
+        }
+    }
+
+    /// Load config with optional project-config suppression and an optional
+    /// named profile overlay. Layer order, lowest to highest precedence:
+    /// global -> project `.foundry.json` (skipped when `ignore_project`) ->
+    /// named profile. Env overrides apply last, as in [`Config::load`]. Returns
+    /// an error only for an unknown profile name.
+    pub fn load_layered(
+        project_dir: &Path,
+        ignore_project: bool,
+        profile: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let global_val = Self::global_config_path()
+            .as_deref()
+            .and_then(Self::read_json_file);
+        let project_val = if ignore_project {
+            None
+        } else {
+            Self::read_json_file(&project_dir.join(".foundry.json"))
+        };
+
+        let mut merged = match (global_val, project_val) {
+            (Some(g), Some(p)) => Some(Self::merge_json(g, p)),
+            (Some(g), None) => Some(g),
+            (None, Some(p)) => Some(p),
+            (None, None) => None,
+        };
+
+        if let Some(name) = profile {
+            let prof = Self::builtin_profile_json(name)
+                .ok_or_else(|| anyhow::anyhow!("unknown profile '{name}' (known profiles: ci)"))?;
+            merged = Some(match merged {
+                Some(m) => Self::merge_json(m, prof),
+                None => prof,
+            });
+        }
+
+        let mut config = match merged {
+            Some(val) => serde_json::from_value::<Self>(val).unwrap_or_else(|e| {
+                eprintln!("warning: failed to deserialize config: {e} -- using defaults");
+                Self::default()
+            }),
+            None => Self::default(),
+        };
+        config.normalize();
+        config.apply_env_overrides();
+        Ok(config)
     }
 
     /// Build a SandboxConfig from this Config's sandbox fields.
@@ -4018,5 +4091,155 @@ mod tests {
         // Both should have empty builder_models
         assert!(configs[0].builder_models.is_empty());
         assert!(configs[1].builder_models.is_empty());
+    }
+
+    #[test]
+    fn builtin_profile_ci_sets_service_sandbox_off_and_cost_cap() {
+        let p = Config::builtin_profile_json("ci").expect("ci profile exists");
+        assert_eq!(p["run_mode"], "service");
+        assert_eq!(p["sandbox"], false);
+        assert_eq!(p["cost_limit"], 20.0);
+        assert_eq!(
+            p["provider_allowlist"],
+            serde_json::json!(["claude", "codex"])
+        );
+        // ci must NOT pin routing -- it only names behavior/safety fields.
+        assert!(p.get("stage_overrides").is_none());
+        assert!(p.get("builder_provider").is_none());
+        assert!(p.get("builder_model").is_none());
+    }
+
+    #[test]
+    fn builtin_profile_unknown_is_none() {
+        assert!(Config::builtin_profile_json("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn ci_profile_overlay_preserves_stage_routing() {
+        // The load_layered overlay merges the ci profile on top of a project
+        // config that carries per-stage routing. The profile must win on the
+        // fields it names (run_mode, sandbox) while leaving routing intact.
+        let project = serde_json::json!({
+            "run_mode": "auto",
+            "sandbox": true,
+            "builder_provider": "codex",
+            "stage_overrides": ["implement", "doubt"],
+        });
+        let profile = Config::builtin_profile_json("ci").unwrap();
+        let merged = Config::merge_json(project, profile);
+        assert_eq!(merged["run_mode"], "service");
+        assert_eq!(merged["sandbox"], false);
+        assert_eq!(merged["builder_provider"], "codex");
+        assert_eq!(
+            merged["stage_overrides"],
+            serde_json::json!(["implement", "doubt"])
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn load_layered_applies_profile_over_project_over_global() {
+        let home = tempfile::tempdir().unwrap();
+        let foundry_dir = home.path().join(".foundry");
+        fs::create_dir_all(&foundry_dir).unwrap();
+        fs::write(
+            foundry_dir.join("config.json"),
+            r#"{
+                "run_mode":"sprint",
+                "sandbox":true,
+                "builder_provider":"claude",
+                "builder_model":"sonnet",
+                "cost_limit":5.0
+            }"#,
+        )
+        .unwrap();
+
+        let project = tempfile::tempdir().unwrap();
+        fs::write(
+            project.path().join(".foundry.json"),
+            r#"{
+                "run_mode":"auto",
+                "sandbox":true,
+                "builder_provider":"codex",
+                "builder_model":"gpt-5",
+                "stage_overrides":["implement"],
+                "cost_limit":1.0
+            }"#,
+        )
+        .unwrap();
+
+        std::env::set_var("HOME", home.path());
+
+        let config = Config::load_layered(project.path(), false, Some("ci")).unwrap();
+        assert_eq!(config.run_mode, "service");
+        assert!(!config.sandbox);
+        assert_eq!(config.cost_limit, 20.0);
+        assert_eq!(config.provider_allowlist, vec!["claude", "codex"]);
+        assert_eq!(config.builder_provider, "codex");
+        assert_eq!(config.builder_model, "gpt-5");
+        assert_eq!(config.stage_overrides, vec!["implement"]);
+    }
+
+    #[test]
+    #[serial]
+    fn load_layered_ignore_project_skips_project_config_but_applies_profile() {
+        let home = tempfile::tempdir().unwrap();
+        let foundry_dir = home.path().join(".foundry");
+        fs::create_dir_all(&foundry_dir).unwrap();
+        fs::write(
+            foundry_dir.join("config.json"),
+            r#"{"builder_provider":"codex","builder_model":"gpt-5"}"#,
+        )
+        .unwrap();
+
+        let project = tempfile::tempdir().unwrap();
+        fs::write(
+            project.path().join(".foundry.json"),
+            r#"{
+                "builder_provider":"opencode",
+                "builder_model":"ollama/qwen",
+                "on_task_complete":"curl https://example.invalid",
+                "sandbox_env":["ANTHROPIC_API_KEY=exfiltrate"],
+                "stage_overrides":["implement"]
+            }"#,
+        )
+        .unwrap();
+
+        std::env::set_var("HOME", home.path());
+
+        let ignored = Config::load_layered(project.path(), true, Some("ci")).unwrap();
+        assert_eq!(ignored.run_mode, "service");
+        assert!(!ignored.sandbox);
+        assert_eq!(ignored.cost_limit, 20.0);
+        assert_eq!(ignored.provider_allowlist, vec!["claude", "codex"]);
+        assert_eq!(ignored.builder_provider, "codex");
+        assert_eq!(ignored.builder_model, "gpt-5");
+        assert_eq!(ignored.on_task_complete, None);
+        assert!(ignored.sandbox_env.is_empty());
+        assert!(ignored.stage_overrides.is_empty());
+
+        let trusted = Config::load_layered(project.path(), false, Some("ci")).unwrap();
+        assert_eq!(trusted.builder_provider, "opencode");
+        assert_eq!(trusted.builder_model, "ollama/qwen");
+        assert_eq!(
+            trusted.on_task_complete.as_deref(),
+            Some("curl https://example.invalid")
+        );
+        assert_eq!(trusted.sandbox_env, vec!["ANTHROPIC_API_KEY=exfiltrate"]);
+        assert_eq!(trusted.stage_overrides, vec!["implement"]);
+    }
+
+    #[test]
+    #[serial]
+    fn load_layered_unknown_profile_errors() {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+
+        let err = Config::load_layered(project.path(), true, Some("bogus"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown profile 'bogus'"));
+        assert!(err.contains("known profiles: ci"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,19 @@ enum Commands {
         /// Output format for headless mode: "json" (single report) or "json-stream" (JSONL event stream)
         #[arg(long, value_name = "FORMAT")]
         output_format: Option<String>,
+        /// Named config profile overlaid on global+project config (e.g. "ci").
+        /// Headless only.
+        #[arg(long, value_name = "NAME")]
+        profile: Option<String>,
+        /// Ignore project `.foundry.json` (use global config + `--profile` only).
+        /// Use in CI so an untrusted PR branch cannot influence run config.
+        #[arg(long)]
+        ignore_project_config: bool,
+        /// Exit non-zero if any task ends WIP / audit-failed or no task passed.
+        /// Off by default so the build service (which treats WIP as terminal-but-
+        /// ready) is unaffected; the GitHub Action opts in.
+        #[arg(long)]
+        exit_on_wip: bool,
     },
     /// Show current progress
     Status,
@@ -192,14 +205,33 @@ async fn main() -> Result<()> {
     match cli.command.unwrap_or(Commands::Run {
         no_tui: false,
         output_format: None,
+        profile: None,
+        ignore_project_config: false,
+        exit_on_wip: false,
     }) {
         Commands::Run {
             no_tui,
             output_format,
+            profile,
+            ignore_project_config,
+            exit_on_wip,
         } => {
             if no_tui {
-                app::run_headless(&project_dir, output_format).await?;
+                let code = app::run_headless(
+                    &project_dir,
+                    output_format,
+                    profile,
+                    ignore_project_config,
+                    exit_on_wip,
+                )
+                .await?;
+                std::process::exit(code);
             } else {
+                if profile.is_some() || ignore_project_config || exit_on_wip {
+                    eprintln!(
+                        "[foundry] --profile/--ignore-project-config/--exit-on-wip apply to --no-tui headless mode only; ignoring in TUI mode"
+                    );
+                }
                 app::run_tui(&project_dir).await?;
             }
         }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -2624,7 +2624,7 @@ mod ranks_tests {
 
     fn top_5_ids(patterns: &[Pattern], task_desc: &str) -> Vec<String> {
         let mut scored = keyword_scores(patterns, task_desc, &[]);
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.1));
         scored
             .into_iter()
             .take(5)

--- a/src/tui/overlays.rs
+++ b/src/tui/overlays.rs
@@ -2725,7 +2725,7 @@ fn render_prompts_drill_down(
 
     let visible_rows = body_area.height as usize;
     let total_lines = dd.source.lines().count();
-    let scroll = dd.scroll.min(total_lines.saturating_sub(1).max(0));
+    let scroll = dd.scroll.min(total_lines.saturating_sub(1));
     let body_lines: Vec<Line> = dd
         .source
         .lines()


### PR DESCRIPTION
## Summary
Makes the existing `foundry run --no-tui --output-format json-stream` primitive CI-ready so the QRPBA pipeline can run against a checked-out repo from a GitHub Actions runner and open a PR. No new run command, no VPS.

- **`--profile <name>`** config overlay + built-in **`ci`** profile (`run_mode=service`, `sandbox=false`, `cost_limit=20.0`, `provider_allowlist=[claude,codex]`) that **inherits per-stage routing** (not derived from `render_service_profile`).
- **`--exit-on-wip`** opt-in exit policy (default off preserves the build-service WIP-is-ready contract) and **`--ignore-project-config`** trust flag.
- **`.github/workflows/foundry-agent.yml`** — label/dispatch-gated, branch-first, runs headless honoring the trusted default-branch `.foundry.json`, opens a PR + check-run + comment, uploads `.buildloop`.
- **`scripts/foundry-ci-report.py`** — `SessionReport` -> markdown + `--status/--title/--conclusion`.
- Bumps to **v4.1.0**.

Includes fixes from a fresh-context audit: `provider_allowlist` now covers query/research; the workflow honors repo routing (dropped `--ignore-project-config` since it only ever checks out the trusted default branch); rerun-safe issue branches; issue runs gated by author association.

## Verification
- `cargo build` clean; `cargo test --bin foundry` green (provider_allowlist, profile overlay, headless exit policy)
- `actionlint` clean; `python3 -m py_compile` clean
- Local end-to-end: `ci` profile on a trivial task created `hello.txt` + a `feat` commit, exit 0, $0.89 / 61s, report renders correctly

## Not yet proven (post-merge gates)
- [ ] Cut the **v4.1.0 release** so the workflow's downloaded `foundry-linux.tar.gz` has the `--profile` flags
- [ ] Set the **`ANTHROPIC_API_KEY`** secret + create the **`foundry-agent`** label
- [ ] **Clean-runner Claude auth smoke** (T36.1) via a real Actions dispatch -- the last integration gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)